### PR TITLE
acting squished; simplified models

### DIFF
--- a/src/engine/BehaviorCommands.js
+++ b/src/engine/BehaviorCommands.js
@@ -107,11 +107,11 @@ class BehaviorCommands {
                 // If the object has a render distance, check if it should be shown.
                 if (distanceFromMario > gCurrentObject.rawData[oDrawingDistance]) {
                     // Out of render distance, hide the object.
-                    gCurrentObject.header.gfx.flags &= ~GRAPH_RENDER_ACTIVE
+                    gCurrentObject.gfx.flags &= ~GRAPH_RENDER_ACTIVE
                     gCurrentObject.activeFlags |= ACTIVE_FLAG_FAR_AWAY
                 } else if (gCurrentObject.rawData[oHeldState] == HELD_FREE) {
                     // In render distance (and not being held), show the object.
-                    gCurrentObject.header.gfx.flags |= GRAPH_RENDER_ACTIVE
+                    gCurrentObject.gfx.flags |= GRAPH_RENDER_ACTIVE
                     gCurrentObject.activeFlags &= ~ACTIVE_FLAG_FAR_AWAY
                 }
             }
@@ -119,13 +119,13 @@ class BehaviorCommands {
     }
 
     obj_update_gfx_pos_and_angle(obj) {
-        obj.header.gfx.pos[0] = obj.rawData[oPosX]
-        obj.header.gfx.pos[1] = obj.rawData[oPosY] + obj.rawData[oGraphYOffset]
-        obj.header.gfx.pos[2] = obj.rawData[oPosZ]
+        obj.gfx.pos[0] = obj.rawData[oPosX]
+        obj.gfx.pos[1] = obj.rawData[oPosY] + obj.rawData[oGraphYOffset]
+        obj.gfx.pos[2] = obj.rawData[oPosZ]
 
-        obj.header.gfx.angle[0] = obj.rawData[oFaceAnglePitch] & 0xFFFF
-        obj.header.gfx.angle[1] = obj.rawData[oFaceAngleYaw] & 0xFFFF
-        obj.header.gfx.angle[2] = obj.rawData[oFaceAngleRoll] & 0xFFFF
+        obj.gfx.angle[0] = obj.rawData[oFaceAnglePitch] & 0xFFFF
+        obj.gfx.angle[1] = obj.rawData[oFaceAngleYaw] & 0xFFFF
+        obj.gfx.angle[2] = obj.rawData[oFaceAngleRoll] & 0xFFFF
     }
 
 
@@ -303,7 +303,7 @@ class BehaviorCommands {
 
     disable_rendering(args) {
         const gCurrentObject = gLinker.ObjectListProcessor.gCurrentObject
-        gCurrentObject.header.gfx.flags &= ~GRAPH_RENDER_ACTIVE
+        gCurrentObject.gfx.flags &= ~GRAPH_RENDER_ACTIVE
         this.bhvScript.index++
         return this.BHV_PROC_CONTINUE
     }
@@ -349,7 +349,7 @@ class BehaviorCommands {
         const animIndex = args.animIndex
         const animations = gCurrentObject.rawData[oAnimations]
 
-        geo_obj_init_animation(gCurrentObject.header.gfx, animations[animIndex])
+        geo_obj_init_animation(gCurrentObject.gfx, animations[animIndex])
 
         this.bhvScript.index++
         return this.BHV_PROC_CONTINUE
@@ -357,14 +357,14 @@ class BehaviorCommands {
 
     cylboard(args) {
         const gCurrentObject = gLinker.ObjectListProcessor.gCurrentObject
-        gCurrentObject.header.gfx.flags |= GRAPH_RENDER_CYLBOARD
+        gCurrentObject.gfx.flags |= GRAPH_RENDER_CYLBOARD
         this.bhvScript.index++
         return this.BHV_PROC_CONTINUE
     }
 
     billboard(args) {
         const gCurrentObject = gLinker.ObjectListProcessor.gCurrentObject
-        gCurrentObject.header.gfx.flags |= GRAPH_RENDER_BILLBOARD
+        gCurrentObject.gfx.flags |= GRAPH_RENDER_BILLBOARD
         this.bhvScript.index++
         return this.BHV_PROC_CONTINUE
     }

--- a/src/engine/graph_node.js
+++ b/src/engine/graph_node.js
@@ -278,13 +278,12 @@ const get_func = (func, funcClass) => {
 /**
  * Allocates and returns a newly created held object node
  */
-export const init_graph_node_held_object = (graphNode, objNode, translation, func) => {
+export const init_graph_node_held_object = (graphNode, object, translation, func) => {
     let funcClass
     [func, funcClass] = get_func(func)
 
     graphNode = {
-        node: -1,
-        objNode: objNode,
+        object,
         translation: [...translation],
         func: { func, funcClass }
     }
@@ -416,7 +415,6 @@ export const init_graph_node = (graphNode, type) => {
     graphNode.debug = {}
     graphNode.debug.id = gGraphNodeNextID++
     graphNode.debug.type = gGraphNodeTypeNames[type]
-    // graphNode.wrapper = graphNode
 }
 
 export const init_scene_graph_node_links = (graphNode, type) => {
@@ -435,7 +433,6 @@ export const init_graph_node_start = (pool, graphNode) => {
 
 export const init_graph_node_root = (pool, graphNode, areaIndex, x, y, width, height) => {
     graphNode = {
-        node: -1,
         areaIndex, x, y, width, height,
         unk15: 0,
         views: null,
@@ -493,7 +490,6 @@ export const init_graph_node_generated = (pool, graphNode, gfxFunc, parameter, f
 
 export const init_graph_node_object_parent = (sharedChild) => {
     const graphNode = {
-        node: -1,
         sharedChild: sharedChild
     }
 
@@ -503,7 +499,6 @@ export const init_graph_node_object_parent = (sharedChild) => {
 
 export const init_graph_node_animated_part = (drawingLayer, displayList, translation) => {
     const graphNode = {
-        node: -1,
         translation: [ ...translation ],
         displayList
     }
@@ -515,7 +510,6 @@ export const init_graph_node_animated_part = (drawingLayer, displayList, transla
 
 export const init_graph_node_billboard = (drawingLayer, displayList, translation) => {
     const graphNode = {
-        node: -1,
         translation: [...translation],
         displayList
     }
@@ -529,7 +523,6 @@ export const init_graph_node_camera = (pool, graphNode, pos, focus, func, mode) 
     let funcClass
     [func, funcClass] = get_func(func, CameraInstance)
     graphNode = {
-        node: -1,
         roll: 0,
         rollScreen: 0,
         config: { mode: 0, camera: null },
@@ -550,7 +543,6 @@ export const init_graph_node_camera = (pool, graphNode, pos, focus, func, mode) 
 
 export const init_graph_node_display_list = (drawingLayer, displayList) => {
     const graphNode = {
-        node: -1,
         displayList
     }
 
@@ -563,7 +555,6 @@ export const init_graph_node_display_list = (drawingLayer, displayList) => {
 
 export const init_graph_node_background = (pool, graphNode, background, backgroundFunc, zero) => {
     graphNode = {
-        node: -1,
         background,
         backgroundFunc,
         zero
@@ -580,7 +571,6 @@ export const init_graph_node_background = (pool, graphNode, background, backgrou
 
 export const init_graph_node_shadow = (shadowScale, shadowSolidity, shadowType) => {
     const graphNode = {
-        node: -1,
         shadowType,
         shadowScale,
         shadowSolidity
@@ -593,7 +583,6 @@ export const init_graph_node_shadow = (shadowScale, shadowSolidity, shadowType) 
 
 export const init_graph_node_scale = (drawingLayer, displayList, scale) => {
     const graphNode = {
-        node: -1,
         displayList,
         scale
     }
@@ -605,7 +594,6 @@ export const init_graph_node_scale = (drawingLayer, displayList, scale) => {
 
 export const init_graph_node_rotation = (drawingLayer, displayList, rotation) => {
     const graphNode = {
-        node: -1,
         displayList,
         rotation
     }
@@ -617,7 +605,6 @@ export const init_graph_node_rotation = (drawingLayer, displayList, rotation) =>
 
 export const init_graph_node_translation = (drawingLayer, displayList, translation) => {
     const graphNode = {
-        node: -1,
         displayList,
         translation: [...translation]
     }
@@ -629,7 +616,6 @@ export const init_graph_node_translation = (drawingLayer, displayList, translati
 
 export const init_graph_node_translation_rotation = (drawingLayer, displayList, translation, rotation) => {
     const graphNode = {
-        node: -1,
         displayList,
         translation: [...translation],
         rotation: [...rotation]
@@ -642,7 +628,6 @@ export const init_graph_node_translation_rotation = (drawingLayer, displayList, 
 
 export const init_graph_node_ortho = (pool, graphNode, scale) => {
     graphNode = {
-        node: -1,
         scale
     }
 
@@ -652,7 +637,6 @@ export const init_graph_node_ortho = (pool, graphNode, scale) => {
 
 export const init_graph_node_master_list = (pool, graphNode, on) => {
     graphNode = {
-        node: -1,
         listHeads: Array(GFX_NUM_MASTER_LISTS),
     }
     init_scene_graph_node_links(graphNode, GRAPH_NODE_TYPE_MASTER_LIST)

--- a/src/game/Area.js
+++ b/src/game/Area.js
@@ -66,7 +66,7 @@ class Area {
 
     load_obj_warp_nodes() {
         for (const node of gLinker.GeoLayout.gObjParentGraphNode.children) {
-            let object = node.wrapperObjectNode.wrapperObject
+            let object = node.object
 
             if (object.activeFlags != ACTIVE_FLAG_DEACTIVATED && gLinker.LevelUpdate.get_mario_spawn_type(object) != 0) {
                 let warp_node = this.area_get_warp_node_from_params(object)
@@ -97,7 +97,7 @@ class Area {
 
     unload_area() {
         if (this.gCurrentArea) {
-            gLinker.ObjectListProcessor.unload_objects_from_area(0, this.gCurrentArea.index)
+            gLinker.ObjectListProcessor.unload_objects_from_area(this.gCurrentArea.index)
             geo_call_global_function_nodes(this.gCurrentArea.geometryLayoutData, GEO_CONTEXT_AREA_UNLOAD)
 
             this.gCurrentArea.flags = 0
@@ -120,7 +120,7 @@ class Area {
 
     unload_mario_area() {
         if (this.gCurrentArea && (this.gCurrentArea.flags & 0x01)) {
-            gLinker.ObjectListProcessor.unload_objects_from_area(0, this.gMarioSpawnInfo.activeAreaIndex)
+            gLinker.ObjectListProcessor.unload_objects_from_area(this.gMarioSpawnInfo.activeAreaIndex)
 
             this.gCurrentArea.flags &= ~0x01
             if (this.gCurrentArea.flags == 0) {

--- a/src/game/Interaction.js
+++ b/src/game/Interaction.js
@@ -191,7 +191,7 @@ const check_death_barrier = (m) => {
     //// the actual code
     /*    if (m -> pos[1] < m -> floorHeight + 2048.0f) {
             if (level_trigger_warp(m, WARP_OP_WARP_FLOOR) == 20 && !(m -> flags & MARIO_UNKNOWN_18)) {
-                play_sound(SOUND_MARIO_WAAAOOOW, m -> marioObj -> header.gfx.cameraToObject)
+                play_sound(SOUND_MARIO_WAAAOOOW, m -> marioObj -> .gfx.cameraToObject)
             }
         }*/
 
@@ -284,7 +284,7 @@ export const interact_warp = (m, o) => {
             // play_sound(o.collisionData == warp_pipe_seg3_collision_03009AC8
             //                ? SOUND_MENU_ENTER_PIPE
             //                : SOUND_MENU_ENTER_HOLE,
-            //            m.marioObj.header.gfx.cameraToObject)
+            //            m.marioObj.gfx.cameraToObject)
 
             mario_stop_riding_object(m)
             return set_mario_action(m, ACT_DISAPPEARED, (WARP_OP_WARP_OBJECT << 16) + 2)
@@ -596,8 +596,8 @@ export const interact_cap = (m, o) => {
             m.flags |= MARIO_CAP_ON_HEAD
         }
 
-        // play_sound(SOUND_MENU_STAR_SOUND, m.marioObj.header.gfx.cameraToObject)
-        // play_sound(SOUND_MARIO_HERE_WE_GO, m.marioObj.header.gfx.cameraToObject)
+        // play_sound(SOUND_MENU_STAR_SOUND, m.marioObj.gfx.cameraToObject)
+        // play_sound(SOUND_MARIO_HERE_WE_GO, m.marioObj.gfx.cameraToObject)
 
         if (capMusic != 0) {
             play_cap_music(capMusic)
@@ -656,7 +656,7 @@ const mario_can_talk = (m, arg) => {
             return 1
         }
 
-        val6 = m.marioObj.header.gfx.unk38.animID
+        val6 = m.marioObj.gfx.unk38.animID
 
         if (val6 == 0x0080 || val6 == 0x007F || val6 == 0x006C) {
             return 1
@@ -907,7 +907,7 @@ const bounce_off_object = (m, o, velY) => {
 
     m.flags &= ~MARIO_UNKNOWN_08
 
-    //play_sound(SOUND_ACTION_BOUNCE_OFF_OBJECT, m -> marioObj -> header.gfx.cameraToObject)
+    //play_sound(SOUND_ACTION_BOUNCE_OFF_OBJECT, m -> marioObj -> .gfx.cameraToObject)
 }
 
 const hit_object_from_below = (m, o) => {
@@ -933,7 +933,7 @@ const bounce_back_from_attack = (m, interaction) => {
     }
 
     if (interaction & (INT_PUNCH | INT_KICK | INT_TRIP | INT_FAST_ATTACK_OR_SHELL)) {
-        //play_sound(SOUND_ACTION_HIT_2, m -> marioObj -> header.gfx.cameraToObject)
+        //play_sound(SOUND_ACTION_HIT_2, m -> marioObj -> .gfx.cameraToObject)
     }
 }
 
@@ -1182,11 +1182,11 @@ const check_kick_or_punch_wall = (m) => {
                 }
 
                 set_forward_vel(m, -48.0);
-                // play_sound(SOUND_ACTION_HIT_2, m->marioObj->header.gfx.cameraToObject);
+                // play_sound(SOUND_ACTION_HIT_2, m->marioObj->.gfx.cameraToObject);
                 m.particleFlags |= MarioConstants.PARTICLE_TRIANGLE;
             } else if (m.action & ACT_FLAG_AIR) {
                 set_forward_vel(m, -16.0);
-                // play_sound(SOUND_ACTION_HIT_2, m->marioObj->header.gfx.cameraToObject);
+                // play_sound(SOUND_ACTION_HIT_2, m->marioObj->.gfx.cameraToObject);
                 m.particleFlags |= MarioConstants.PARTICLE_TRIANGLE;
             }
         }

--- a/src/game/LevelUpdate.js
+++ b/src/game/LevelUpdate.js
@@ -822,7 +822,7 @@ class LevelUpdate {
 
 //                 Mario.set_mario_action(gMarioState, ACT_DISAPPEARED, 0)
 
-//                 gMarioState.marioObj.header.gfx.flags &= ~GRAPH_RENDER_ACTIVE
+//                 gMarioState.marioObj.gfx.flags &= ~GRAPH_RENDER_ACTIVE
 
 //                 play_sound(SOUND_MENU_STAR_SOUND, gGlobalSoundSource)
 //                 fadeout_music(398)
@@ -1192,7 +1192,7 @@ class LevelUpdate {
                     }
     
                     this.gHudDisplay.coins += 1;
-                    //play_sound(coinSound, this.gMarioState.marioObj.header.gfx.cameraToObject)
+                    //play_sound(coinSound, this.gMarioState.marioObj.gfx.cameraToObject)
                 }
             }
     

--- a/src/game/MacroSpecialObjects.js
+++ b/src/game/MacroSpecialObjects.js
@@ -162,7 +162,11 @@ export const spawn_special_objects = (areaIndex, specialObjList, dataIndex) => {
     SpecialObjectPresets_init()
     const numOfSpecialObjects = specialObjList[dataIndex++]
     ObjectListProc.gMacroObjectDefaultParent = {
-        header: { gfx: { areaIndex: areaIndex, activeAreaIndex: areaIndex } } }
+        gfx: {
+            areaIndex: areaIndex,
+            activeAreaIndex: areaIndex
+        }
+    }
 
     for (let i = 0; i < numOfSpecialObjects; i++) {
         const presetID = specialObjList[dataIndex++]
@@ -204,8 +208,8 @@ export const spawn_special_objects = (areaIndex, specialObjList, dataIndex) => {
 }
 
 export const spawn_macro_objects = (areaIndex, macroObjList) => {
-    ObjectListProc.gMacroObjectDefaultParent.header.gfx.areaIndex = areaIndex
-    ObjectListProc.gMacroObjectDefaultParent.header.gfx.activeAreaIndex = areaIndex
+    ObjectListProc.gMacroObjectDefaultParent.gfx.areaIndex = areaIndex
+    ObjectListProc.gMacroObjectDefaultParent.gfx.activeAreaIndex = areaIndex
 
     let p, preset
 

--- a/src/game/MarioActionsAirborne.js
+++ b/src/game/MarioActionsAirborne.js
@@ -160,9 +160,9 @@ import {
 
 
 const play_flip_sounds = (m, frame1, frame2, frame3) => {
-    let animFrame = m.marioObj.header.gfx.unk38.animFrame
+    let animFrame = m.marioObj.gfx.unk38.animFrame
     if (animFrame == frame1 || animFrame == frame2 || animFrame == frame3) {
-        play_sound(SOUND_ACTION_SPIN, m.marioObj.header.gfx.cameraToObject)
+        play_sound(SOUND_ACTION_SPIN, m.marioObj.gfx.cameraToObject)
     }
 }
 
@@ -171,7 +171,7 @@ const play_far_fall_sound = (m) => {
     if (!(action & ACT_FLAG_INVULNERABLE) && action != ACT_TWIRLING && action != ACT_FLYING
         && !(m.flags & MARIO_UNKNOWN_18)) {
         if (m.peakHeight - m.pos[1] > 1150.0) {
-            play_sound(SOUND_MARIO_WAAAOOOW, m.marioObj.header.gfx.cameraToObject)
+            play_sound(SOUND_MARIO_WAAAOOOW, m.marioObj.gfx.cameraToObject)
             m.flags |= MARIO_UNKNOWN_18
         }
     }
@@ -196,7 +196,7 @@ export const lava_boost_on_wall = (m) => {
         m.hurtCounter += (m.flags & MARIO_CAP_ON_HEAD) ? 12 : 18
     }
 
-    play_sound(SOUND_MARIO_ON_FIRE, m.marioObj.header.gfx.cameraToObject)
+    play_sound(SOUND_MARIO_ON_FIRE, m.marioObj.gfx.cameraToObject)
     update_mario_sound_and_camera(m)
     return drop_and_set_mario_action(m, ACT_LAVA_BOOST, 1)
 }
@@ -219,13 +219,13 @@ export const check_fall_damage = (m, hardFallAction) => {
             if (fallHeight > 3000.0) {
                 m.hurtCounter += (m.flags & MARIO_CAP_ON_HEAD) ? 16 : 24
                 Camera.set_camera_shake_from_hit(CAMERA.SHAKE_FALL_DAMAGE)
-                play_sound(SOUND_MARIO_ATTACKED, m.marioObj.header.gfx.cameraToObject)
+                play_sound(SOUND_MARIO_ATTACKED, m.marioObj.gfx.cameraToObject)
                 return drop_and_set_mario_action(m, hardFallAction, 4)
             } else if (fallHeight > damageHeight && !mario_floor_is_slippery(m)) {
                 m.hurtCounter += (m.flags & MARIO_CAP_ON_HEAD) ? 8 : 12
                 m.squishTimer = 30
                 Camera.set_camera_shake_from_hit(CAMERA.SHAKE_FALL_DAMAGE)
-                play_sound(SOUND_MARIO_ATTACKED, m.marioObj.header.gfx.cameraToObject)
+                play_sound(SOUND_MARIO_ATTACKED, m.marioObj.gfx.cameraToObject)
             }
         }
     }
@@ -258,7 +258,7 @@ export const should_get_stuck_in_ground = (m) => {
 
 export const check_fall_damage_or_get_stuck = (m, hardFallAction) => {
     if (should_get_stuck_in_ground(m)) {
-        play_sound(SOUND_MARIO_OOOF2, m.marioObj.header.gfx.cameraToObject)
+        play_sound(SOUND_MARIO_OOOF2, m.marioObj.gfx.cameraToObject)
         m.particleFlags |= PARTICLE_MIST_CIRCLE
         drop_and_set_mario_action(m, ACT_FEET_STUCK_IN_GROUND, 0)
         return 1
@@ -704,11 +704,11 @@ export const act_side_flip = (m) => {
 
     if (common_air_action_step(m, ACT_SIDE_FLIP_LAND, MARIO_ANIM_SLIDEFLIP, AIR_STEP_CHECK_LEDGE_GRAB)
         != AIR_STEP_GRABBED_LEDGE) {
-        m.marioObj.header.gfx.angle[1] = s16(m.marioObj.header.gfx.angle[1] + 0x8000)
+        m.marioObj.gfx.angle[1] = s16(m.marioObj.gfx.angle[1] + 0x8000)
     }
 
-    if (m.marioObj.header.gfx.unk38.animFrame == 6) {
-        play_sound(SOUND_ACTION_SIDE_FLIP_UNK, m.marioObj.header.gfx.cameraToObject)
+    if (m.marioObj.gfx.unk38.animFrame == 6) {
+        play_sound(SOUND_ACTION_SIDE_FLIP_UNK, m.marioObj.gfx.cameraToObject)
     }
 
     return 0
@@ -739,7 +739,7 @@ export const act_long_jump = (m) => {
     play_mario_sound(m, SOUND_ACTION_TERRAIN_JUMP, SOUND_MARIO_YAHOO)
 
     if (m.floor.type == SURFACE_VERTICAL_WIND && m.actionState == 0) {
-        play_sound(SOUND_MARIO_HERE_WE_GO, m.marioObj.header.gfx.cameraToObject)
+        play_sound(SOUND_MARIO_HERE_WE_GO, m.marioObj.gfx.cameraToObject)
         m.actionState = 1
     }
 
@@ -767,7 +767,7 @@ export const act_riding_shell_air = (m) => {
             break
     }
 
-    m.marioObj.header.gfx.pos[1] += 42.0
+    m.marioObj.gfx.pos[1] += 42.0
     return 0
 }
 
@@ -790,7 +790,7 @@ export const act_twirling = (m) => {
     }
 
     if (startTwirlYaw > m.twirlYaw) {
-        play_sound(SOUND_ACTION_TWIRL, m.marioObj.header.gfx.cameraToObject)
+        play_sound(SOUND_ACTION_TWIRL, m.marioObj.gfx.cameraToObject)
     }
 
     update_lava_boost_or_twirling(m)
@@ -809,7 +809,7 @@ export const act_twirling = (m) => {
             break
     }
 
-    m.marioObj.header.gfx.angle[1] = s16(m.marioObj.header.gfx.angle[1] + m.twirlYaw)
+    m.marioObj.gfx.angle[1] = s16(m.marioObj.gfx.angle[1] + m.twirlYaw)
     return 0
 }
 
@@ -839,12 +839,12 @@ export const act_dive = (m) => {
                     m.faceAngle[0] = -0x2AAA
                 }
             }
-            m.marioObj.header.gfx.angle[0] = -m.faceAngle[0]
+            m.marioObj.gfx.angle[0] = -m.faceAngle[0]
             break
 
         case AIR_STEP_LANDED:
             if (should_get_stuck_in_ground(m) && m.faceAngle[0] == -0x2AAA) {
-                play_sound(SOUND_MARIO_OOOF2, m.marioObj.header.gfx.cameraToObject)
+                play_sound(SOUND_MARIO_OOOF2, m.marioObj.gfx.cameraToObject)
                 m.particleFlags |= PARTICLE_MIST_CIRCLE
                 drop_and_set_mario_action(m, ACT_HEAD_STUCK_IN_GROUND, 0)
             } else if (!check_fall_damage(m, ACT_HARD_FORWARD_GROUND_KB)) {
@@ -993,7 +993,7 @@ export const act_steep_jump = (m) => {
     }
 
     set_mario_animation(m, MARIO_ANIM_SINGLE_JUMP)
-    m.marioObj.header.gfx.angle[1] = m.marioObj.rawData[oMarioSteepJumpYaw]
+    m.marioObj.gfx.angle[1] = m.marioObj.rawData[oMarioSteepJumpYaw]
     return 0
 }
 
@@ -1009,7 +1009,7 @@ export const act_ground_pound = (m) => {
             if (m.pos[1] + yOffset + 160.0 < m.ceilHeight) {
                 m.pos[1] += yOffset
                 m.peakHeight = m.pos[1]
-                vec3f_copy(m.marioObj.header.gfx.pos, m.pos)
+                vec3f_copy(m.marioObj.gfx.pos, m.pos)
             }
         }
 
@@ -1019,12 +1019,12 @@ export const act_ground_pound = (m) => {
         set_mario_animation(m, m.actionArg == 0 ? MARIO_ANIM_START_GROUND_POUND
                                                  : MARIO_ANIM_TRIPLE_JUMP_GROUND_POUND)
         if (m.actionTimer == 0) {
-            play_sound(SOUND_ACTION_SPIN, m.marioObj.header.gfx.cameraToObject)
+            play_sound(SOUND_ACTION_SPIN, m.marioObj.gfx.cameraToObject)
         }
 
         m.actionTimer++
-        if (m.actionTimer >= m.marioObj.header.gfx.unk38.curAnim.unk08 + 4) {
-            play_sound(SOUND_MARIO_GROUND_POUND_WAH, m.marioObj.header.gfx.cameraToObject)
+        if (m.actionTimer >= m.marioObj.gfx.unk38.curAnim.unk08 + 4) {
+            play_sound(SOUND_MARIO_GROUND_POUND_WAH, m.marioObj.gfx.cameraToObject)
             m.actionState = 1
         }
     } else {
@@ -1033,7 +1033,7 @@ export const act_ground_pound = (m) => {
         stepResult = perform_air_step(m, 0)
         if (stepResult == AIR_STEP_LANDED) {
             if (should_get_stuck_in_ground(m)) {
-                play_sound(SOUND_MARIO_OOOF2, m.marioObj.header.gfx.cameraToObject)
+                play_sound(SOUND_MARIO_OOOF2, m.marioObj.gfx.cameraToObject)
                 m.particleFlags |= PARTICLE_MIST_CIRCLE
                 set_mario_action(m, ACT_BUTT_STUCK_IN_GROUND, 0)
             } else {
@@ -1069,7 +1069,7 @@ export const act_burning_jump = (m) => {
 
     set_mario_animation(m, m.actionArg == 0 ? MARIO_ANIM_SINGLE_JUMP : MARIO_ANIM_FIRE_LAVA_BURN)
     m.particleFlags |= PARTICLE_FIRE
-    play_sound(SOUND_MOVING_LAVA_BURN, m.marioObj.header.gfx.cameraToObject)
+    play_sound(SOUND_MOVING_LAVA_BURN, m.marioObj.gfx.cameraToObject)
 
     m.marioObj.rawData[oMarioBurnTimer] += 3
 
@@ -1121,7 +1121,7 @@ export const act_crazy_box_bounce = (m) => {
         }
 
         play_sound(minSpeed < 40.0 ? SOUND_GENERAL_BOING1 : SOUND_GENERAL_BOING2,
-                   m.marioObj.header.gfx.cameraToObject)
+                   m.marioObj.gfx.cameraToObject)
 
         if (m.forwardVel < minSpeed) {
             mario_set_forward_vel(m, minSpeed)
@@ -1156,7 +1156,7 @@ export const act_crazy_box_bounce = (m) => {
             break
     }
 
-    m.marioObj.header.gfx.angle[0] = atan2s(m.forwardVel, -m.vel[1])
+    m.marioObj.gfx.angle[0] = atan2s(m.forwardVel, -m.vel[1])
     return 0
 }
 
@@ -1277,7 +1277,7 @@ export const act_thrown_forward = (m) => {
             pitch = 0x1800
         }
 
-        m.marioObj.header.gfx.angle[0] = s16(pitch + 0x1800)
+        m.marioObj.gfx.angle[0] = s16(pitch + 0x1800)
     }
 
     m.forwardVel *= 0.98
@@ -1393,7 +1393,7 @@ export const act_forward_rollout = (m) => {
         case AIR_STEP_NONE:
             if (m.actionState == 1) {
                 if (set_mario_animation(m, MARIO_ANIM_FORWARD_SPINNING) == 4) {
-                    play_sound(SOUND_ACTION_SPIN, m.marioObj.header.gfx.cameraToObject)
+                    play_sound(SOUND_ACTION_SPIN, m.marioObj.gfx.cameraToObject)
                 }
             } else {
                 set_mario_animation(m, MARIO_ANIM_GENERAL_FALL)
@@ -1434,7 +1434,7 @@ export const act_backward_rollout = (m) => {
         case AIR_STEP_NONE:
             if (m.actionState == 1) {
                 if (set_mario_animation(m, MARIO_ANIM_BACKWARD_SPINNING) == 4) {
-                    play_sound(SOUND_ACTION_SPIN, m.marioObj.header.gfx.cameraToObject)
+                    play_sound(SOUND_ACTION_SPIN, m.marioObj.gfx.cameraToObject)
                 }
             } else {
                 set_mario_animation(m, MARIO_ANIM_GENERAL_FALL)
@@ -1455,7 +1455,7 @@ export const act_backward_rollout = (m) => {
             break
     }
 
-    if (m.actionState == 1 && m.marioObj.header.gfx.unk38.animFrame == 2) {
+    if (m.actionState == 1 && m.marioObj.gfx.unk38.animFrame == 2) {
         m.actionState = 2
     }
     return 0
@@ -1554,7 +1554,7 @@ export const act_lava_boost = (m) => {
                     m.hurtCounter += (m.flags & MARIO_CAP_ON_HEAD) ? 12 : 18
                 }
                 m.vel[1] = 84.0
-                play_sound(SOUND_MARIO_ON_FIRE, m.marioObj.header.gfx.cameraToObject)
+                play_sound(SOUND_MARIO_ON_FIRE, m.marioObj.gfx.cameraToObject)
             } else {
                 play_mario_heavy_landing_sound(m, SOUND_ACTION_TERRAIN_BODY_HIT_GROUND)
                 if (m.actionState < 2 && m.vel[1] < 0.0) {
@@ -1581,7 +1581,7 @@ export const act_lava_boost = (m) => {
         && m.vel[1] > 0.0) {
         m.particleFlags |= PARTICLE_FIRE
         if (m.actionState == 0) {
-            play_sound(SOUND_MOVING_LAVA_BURN, m.marioObj.header.gfx.cameraToObject)
+            play_sound(SOUND_MOVING_LAVA_BURN, m.marioObj.gfx.cameraToObject)
         }
     }
 
@@ -1608,9 +1608,9 @@ export const act_slide_kick = (m) => {
     switch (perform_air_step(m, 0)) {
         case AIR_STEP_NONE:
             if (m.actionState == 0) {
-                m.marioObj.header.gfx.angle[0] = atan2s(m.forwardVel, -m.vel[1])
-                if (m.marioObj.header.gfx.angle[0] > 0x1800) {
-                    m.marioObj.header.gfx.angle[0] = 0x1800
+                m.marioObj.gfx.angle[0] = atan2s(m.forwardVel, -m.vel[1])
+                if (m.marioObj.gfx.angle[0] > 0x1800) {
+                    m.marioObj.gfx.angle[0] = 0x1800
                 }
             }
             break
@@ -1649,12 +1649,12 @@ export const act_jump_kick = (m) => {
 
     if (m.actionState == 0) {
         play_sound_if_no_flag(m, SOUND_MARIO_PUNCH_HOO, MARIO_ACTION_SOUND_PLAYED)
-        m.marioObj.header.gfx.unk38.animID = -1
+        m.marioObj.gfx.unk38.animID = -1
         set_mario_animation(m, MARIO_ANIM_AIR_KICK)
         m.actionState = 1
     }
 
-    animFrame = m.marioObj.header.gfx.unk38.animFrame
+    animFrame = m.marioObj.gfx.unk38.animFrame
     if (animFrame == 0) {
         m.marioBodyState.punchState = (2 << 6) | 6
     }
@@ -1681,7 +1681,7 @@ export const act_jump_kick = (m) => {
 
 export const act_shot_from_cannon = (m) => {
     if (m.area.camera.mode != CAMERA.CAMERA_MODE_BEHIND_MARIO) {
-        m.statusForCamera.cameraEvent = CAMERA.CAMERA_EVENT_SHOT_FROM_CANNON
+        m.statusForCamera.cameraEvent = CAMERA.CAM_EVENT_SHOT_FROM_CANNON
     }
 
     mario_set_forward_vel(m, m.forwardVel)
@@ -1692,7 +1692,7 @@ export const act_shot_from_cannon = (m) => {
         case AIR_STEP_NONE:
             set_mario_animation(m, MARIO_ANIM_AIRBORNE_ON_STOMACH)
             m.faceAngle[0] = atan2s(m.forwardVel, m.vel[1])
-            m.marioObj.header.gfx.angle[0] = -m.faceAngle[0]
+            m.marioObj.gfx.angle[0] = -m.faceAngle[0]
             break
 
         case AIR_STEP_LANDED:
@@ -1759,8 +1759,8 @@ export const act_flying = (m) => {
             set_mario_animation(m, MARIO_ANIM_FLY_FROM_CANNON)
         } else {
             set_mario_animation(m, MARIO_ANIM_FORWARD_SPINNING_FLIP)
-            if (m.marioObj.header.gfx.unk38.animFrame == 1) {
-                play_sound(SOUND_ACTION_SPIN, m.marioObj.header.gfx.cameraToObject)
+            if (m.marioObj.gfx.unk38.animFrame == 1) {
+                play_sound(SOUND_ACTION_SPIN, m.marioObj.gfx.cameraToObject)
             }
         }
 
@@ -1779,8 +1779,8 @@ export const act_flying = (m) => {
 
     switch (perform_air_step(m, 0)) {
         case AIR_STEP_NONE:
-            m.marioObj.header.gfx.angle[0] = -m.faceAngle[0]
-            m.marioObj.header.gfx.angle[2] = m.faceAngle[2]
+            m.marioObj.gfx.angle[0] = -m.faceAngle[0]
+            m.marioObj.gfx.angle[2] = m.faceAngle[2]
             m.actionTimer = 0
             break
 
@@ -1805,14 +1805,14 @@ export const act_flying = (m) => {
 
                 play_sound((m.flags & MARIO_METAL_CAP) ? SOUND_ACTION_METAL_BONK
                                                        : SOUND_ACTION_BONK,
-                           m.marioObj.header.gfx.cameraToObject)
+                           m.marioObj.gfx.cameraToObject)
 
                 m.particleFlags |= PARTICLE_VERTICAL_STAR
                 set_mario_action(m, ACT_BACKWARD_AIR_KB, 0)
                 Camera.set_camera_mode(m.area.camera, m.area.camera.defMode, 1)
             } else {
                 if (m.actionTimer++ == 0) {
-                    play_sound(SOUND_ACTION_HIT, m.marioObj.header.gfx.cameraToObject)
+                    play_sound(SOUND_ACTION_HIT, m.marioObj.gfx.cameraToObject)
                 }
 
                 if (m.actionTimer == 30) {
@@ -1824,8 +1824,8 @@ export const act_flying = (m) => {
                     m.faceAngle[0] = -0x2AAA
                 }
 
-                m.marioObj.header.gfx.angle[0] = -m.faceAngle[0]
-                m.marioObj.header.gfx.angle[2] = m.faceAngle[2]
+                m.marioObj.gfx.angle[0] = -m.faceAngle[0]
+                m.marioObj.gfx.angle[2] = m.faceAngle[2]
             }
             break
 
@@ -1839,12 +1839,12 @@ export const act_flying = (m) => {
     }
 
     if (startPitch <= 0 && m.faceAngle[0] > 0 && m.forwardVel >= 48.0) {
-        play_sound(SOUND_ACTION_FLYING_FAST, m.marioObj.header.gfx.cameraToObject)
+        play_sound(SOUND_ACTION_FLYING_FAST, m.marioObj.gfx.cameraToObject)
         play_sound(SOUND_MARIO_YAHOO_WAHA_YIPPEE + ((gAudioRandom % 5) << 16),
-                   m.marioObj.header.gfx.cameraToObject)
+                   m.marioObj.gfx.cameraToObject)
     }
 
-    play_sound(SOUND_MOVING_FLYING, m.marioObj.header.gfx.cameraToObject)
+    play_sound(SOUND_MOVING_FLYING, m.marioObj.gfx.cameraToObject)
     adjust_sound_for_speed(m)
     return 0
 }
@@ -1873,8 +1873,8 @@ export const act_riding_hoot = (m) => {
     }
 
     vec3f_set(m.vel, 0.0, 0.0, 0.0)
-    vec3f_set(m.marioObj.header.gfx.pos, m.pos[0], m.pos[1], m.pos[2])
-    vec3s_set(m.marioObj.header.gfx.angle, 0, s16(0x4000 - m.faceAngle[1]), 0)
+    vec3f_set(m.marioObj.gfx.pos, m.pos[0], m.pos[1], m.pos[2])
+    vec3s_set(m.marioObj.gfx.angle, 0, s16(0x4000 - m.faceAngle[1]), 0)
     return 0
 }
 
@@ -1894,8 +1894,8 @@ export const act_flying_triple_jump = (m) => {
     if (m.actionState == 0) {
         set_mario_animation(m, MARIO_ANIM_TRIPLE_JUMP_FLY)
 
-        if (m.marioObj.header.gfx.unk38.animFrame == 7) {
-            play_sound(SOUND_ACTION_SPIN, m.marioObj.header.gfx.cameraToObject)
+        if (m.marioObj.gfx.unk38.animFrame == 7) {
+            play_sound(SOUND_ACTION_SPIN, m.marioObj.gfx.cameraToObject)
         }
 
         if (is_anim_past_end(m)) {
@@ -1904,8 +1904,8 @@ export const act_flying_triple_jump = (m) => {
         }
     }
 
-    if (m.actionState == 1 && m.marioObj.header.gfx.unk38.animFrame == 1) {
-        play_sound(SOUND_ACTION_SPIN, m.marioObj.header.gfx.cameraToObject)
+    if (m.actionState == 1 && m.marioObj.gfx.unk38.animFrame == 1) {
+        play_sound(SOUND_ACTION_SPIN, m.marioObj.gfx.cameraToObject)
     }
 
     if (m.vel[1] < 4.0) {
@@ -1958,8 +1958,8 @@ export const act_vertical_wind = (m) => {
     play_sound_if_no_flag(m, SOUND_MARIO_HERE_WE_GO, MARIO_MARIO_SOUND_PLAYED)
     if (m.actionState == 0) {
         set_mario_animation(m, MARIO_ANIM_FORWARD_SPINNING_FLIP)
-        if (m.marioObj.header.gfx.unk38.animFrame == 1) {
-            play_sound(SOUND_ACTION_SPIN, m.marioObj.header.gfx.cameraToObject)
+        if (m.marioObj.gfx.unk38.animFrame == 1) {
+            play_sound(SOUND_ACTION_SPIN, m.marioObj.gfx.cameraToObject)
         }
 
         if (is_anim_past_end(m)) {
@@ -1981,8 +1981,8 @@ export const act_vertical_wind = (m) => {
             break
     }
 
-    m.marioObj.header.gfx.angle[0] = s16(6144.0 * intendedMag * coss(intendedDYaw))
-    m.marioObj.header.gfx.angle[2] = s16(-4096.0 * intendedMag * sins(intendedDYaw))
+    m.marioObj.gfx.angle[0] = s16(6144.0 * intendedMag * coss(intendedDYaw))
+    m.marioObj.gfx.angle[2] = s16(-4096.0 * intendedMag * sins(intendedDYaw))
     return 0
 }
 
@@ -2016,7 +2016,7 @@ export const act_special_triple_jump = (m) => {
 
     if (m.actionState == 0 || m.vel[1] > 0.0) {
         if (set_mario_animation(m, MARIO_ANIM_FORWARD_SPINNING) == 0) {
-            play_sound(SOUND_ACTION_SPIN, m.marioObj.header.gfx.cameraToObject)
+            play_sound(SOUND_ACTION_SPIN, m.marioObj.gfx.cameraToObject)
         }
     } else {
         set_mario_animation(m, MARIO_ANIM_GENERAL_FALL)

--- a/src/game/MarioActionsAutomatic.js
+++ b/src/game/MarioActionsAutomatic.js
@@ -41,7 +41,7 @@ const update_hang_stationary = (m) => {
 
     m.pos[1] = m.ceilHeight - 160.0
     m.vel = [0, 0, 0]
-    m.marioObj.header.gfx.pos = [...m.pos]
+    m.marioObj.gfx.pos = [...m.pos]
 }
 
 const update_hang_moving = (m) => {
@@ -71,8 +71,8 @@ const update_hang_moving = (m) => {
     
     const stepResult = perform_hanging_step(m, nextPos)
 
-    m.marioObj.header.gfx.pos = [...m.pos]
-    m.marioObj.header.gfx.angle = [0, m.faceAngle[1], 0]
+    m.marioObj.gfx.pos = [...m.pos]
+    m.marioObj.gfx.angle = [0, m.faceAngle[1], 0]
 
     return stepResult
 }
@@ -155,8 +155,8 @@ const set_pole_position = (m, offsetY) => {
         throw "collision on pole"
     }
 
-    m.marioObj.header.gfx.pos = [...m.pos]
-    m.marioObj.header.gfx.angle = [
+    m.marioObj.gfx.pos = [...m.pos]
+    m.marioObj.gfx.angle = [
         m.usedObj.rawData[oMoveAnglePitch],
         m.faceAngle[1],
         m.usedObj.rawData[oMoveAngleRoll]
@@ -355,8 +355,8 @@ const act_hang_moving = (m) => {
         Mario.set_mario_animation(m, Mario.MARIO_ANIM_MOVE_ON_WIRE_NET_LEFT)
     }
 
-    // if (m.marioObj.header.gfx.unk38.animFrame == 12) {
-    //     play_sound(SOUND_ACTION_HANGING_STEP, m.marioObj.header.gfx.cameraToObject)
+    // if (m.marioObj.gfx.unk38.animFrame == 12) {
+    //     play_sound(SOUND_ACTION_HANGING_STEP, m.marioObj.gfx.cameraToObject)
     //     queue_rumble_data(5, 30)
     // }
 
@@ -450,7 +450,7 @@ const climb_up_ledge = (m) => {
     Mario.set_mario_animation(m, Mario.MARIO_ANIM_IDLE_HEAD_LEFT)
     m.pos[0] += 14.0 * Math.sin(m.faceAngle[1] / 0x8000 * Math.PI)
     m.pos[2] += 14.0 * Math.cos(m.faceAngle[1] / 0x8000 * Math.PI)
-    m.marioObj.header.gfx.pos = [...m.pos]
+    m.marioObj.gfx.pos = [...m.pos]
 }
 
 const update_ledge_climb = (m, animation, endAction) => {
@@ -510,7 +510,7 @@ const act_ledge_climb_slow = (m) => {
     update_ledge_climb(m, Mario.MARIO_ANIM_SLOW_LEDGE_GRAB, Mario.ACT_IDLE)
 
     update_ledge_climb_camera(m)
-    if (m.marioObj.header.gfx.unk38.animFrame == 17) {
+    if (m.marioObj.gfx.unk38.animFrame == 17) {
         m.action = Mario.ACT_LEDGE_CLIMB_SLOW_2
     }
 
@@ -526,7 +526,7 @@ const act_ledge_climb_fast = (m) => {
 
     update_ledge_climb(m, Mario.MARIO_ANIM_FAST_LEDGE_GRAB, Mario.ACT_IDLE)
 
-    if (m.marioObj.header.gfx.unk38.animFrame == 8) {
+    if (m.marioObj.gfx.unk38.animFrame == 8) {
         Mario.play_mario_landing_sound(m, SOUND_ACTION_TERRAIN_LANDING)
     }
     update_ledge_climb_camera(m)
@@ -545,7 +545,7 @@ const act_top_of_pole_transition = (m) => {
         }
     } else {
         Mario.set_mario_animation(m, Mario.MARIO_ANIM_RETURN_FROM_HANDSTAND)
-        if (m.marioObj.header.gfx.unk38.animFrame == 0) {
+        if (m.marioObj.gfx.unk38.animFrame == 0) {
             return Mario.set_mario_action(m, Mario.ACT_HOLDING_POLE, 0)
         }
     }
@@ -577,7 +577,7 @@ const act_in_cannon = (m) => {
 
     switch (m.actionState) {
         case 0:
-            m.marioObj.header.gfx.flags &= ~GRAPH_RENDER_ACTIVE
+            m.marioObj.gfx.flags &= ~GRAPH_RENDER_ACTIVE
             m.usedObj.rawData[oInteractStatus] = INT_STATUS_INTERACTED
 
             m.statusForCamera.cameraEvent = Camera.CAM_EVENT_CANNON
@@ -634,24 +634,24 @@ const act_in_cannon = (m) => {
                 m.pos[1] += 120.0 * sins(m.faceAngle[0])
                 m.pos[2] += 120.0 * coss(m.faceAngle[0]) * coss(m.faceAngle[1])
 
-                play_sound(SOUND_ACTION_FLYING_FAST, m.marioObj.header.gfx.cameraToObject)
-                play_sound(SOUND_OBJ_POUNDING_CANNON, m.marioObj.header.gfx.cameraToObject)
+                play_sound(SOUND_ACTION_FLYING_FAST, m.marioObj.gfx.cameraToObject)
+                play_sound(SOUND_OBJ_POUNDING_CANNON, m.marioObj.gfx.cameraToObject)
 
-                m.marioObj.header.gfx.flags |= GRAPH_RENDER_ACTIVE
+                m.marioObj.gfx.flags |= GRAPH_RENDER_ACTIVE
 
                 Mario.set_mario_action(m, Mario.ACT_SHOT_FROM_CANNON, 0)
                 m.usedObj.rawData[oAction] = 2
                 return 0
             } else {
                 if (m.faceAngle[0] != startFacePitch || m.faceAngle[1] != startFaceYaw) {
-                    play_sound(SOUND_MOVING_AIM_CANNON, m.marioObj.header.gfx.cameraToObject)
+                    play_sound(SOUND_MOVING_AIM_CANNON, m.marioObj.gfx.cameraToObject)
                 }
             }
             break
     }
 
-    vec3f_copy(m.marioObj.header.gfx.pos, m.pos)
-    vec3s_set(m.marioObj.header.gfx.angle, 0, m.faceAngle[1], 0)
+    vec3f_copy(m.marioObj.gfx.pos, m.pos)
+    vec3s_set(m.marioObj.gfx.angle, 0, m.faceAngle[1], 0)
     Mario.set_mario_animation(m, Mario.MARIO_ANIM_DIVE)
 
     return 0

--- a/src/game/MarioActionsMoving.js
+++ b/src/game/MarioActionsMoving.js
@@ -143,14 +143,14 @@ export const tilt_body_running = (m) => {
 export const play_step_sound = (m, frame1, frame2) => {
     if (is_anim_past_frame(m, frame1) || is_anim_past_frame(m, frame2)) {
         if (m.flags & MARIO_METAL_CAP) {
-            if (m.marioObj.header.gfx.unk38.animID == MARIO_ANIM_TIPTOE) {
+            if (m.marioObj.gfx.unk38.animID == MARIO_ANIM_TIPTOE) {
                 play_sound_and_spawn_particles(m, SOUND_ACTION_METAL_STEP_TIPTOE, 0)
             } else {
                 play_sound_and_spawn_particles(m, SOUND_ACTION_METAL_STEP, 0)
             }
         } else if (m.quicksandDepth > 50.0) {
-            play_sound(SOUND_ACTION_QUICKSAND_STEP, m.marioObj.header.gfx.cameraToObject)
-        } else if (m.marioObj.header.gfx.unk38.animID == MARIO_ANIM_TIPTOE) {
+            play_sound(SOUND_ACTION_QUICKSAND_STEP, m.marioObj.gfx.cameraToObject)
+        } else if (m.marioObj.gfx.unk38.animID == MARIO_ANIM_TIPTOE) {
             play_sound_and_spawn_particles(m, SOUND_ACTION_TERRAIN_STEP_TIPTOE, 0)
         } else {
             play_sound_and_spawn_particles(m, SOUND_ACTION_TERRAIN_STEP, 0)
@@ -337,7 +337,7 @@ const anim_and_audio_for_walk = (m) => {
         }
         marioObj.rawData[oMarioWalkingPitch] = 
                 s16(approach_s32(marioObj.rawData[oMarioWalkingPitch], targetPitch, 0x800, 0x800))
-        marioObj.header.gfx.angle[0] = marioObj.rawData[oMarioWalkingPitch]
+        marioObj.gfx.angle[0] = marioObj.rawData[oMarioWalkingPitch]
     }
 
 }
@@ -408,7 +408,7 @@ export const anim_and_audio_for_heavy_walk = (m) => {
 
 const tilt_body_walking = (m, startYaw) => {
     const val0C = m.marioBodyState
-    const animID = m.marioObj.header.gfx.unk38.animID
+    const animID = m.marioObj.gfx.unk38.animID
     let dYaw, val02, val00
 
     if (animID == MARIO_ANIM_WALKING || animID == MARIO_ANIM_RUNNING) {
@@ -658,7 +658,7 @@ const act_decelerating = (m) => {
 
     if (slopeClass == SURFACE_CLASS_VERY_SLIPPERY) {
         set_mario_animation(m, MARIO_ANIM_IDLE_HEAD_LEFT)
-        play_sound(SOUND_MOVING_TERRAIN_SLIDE + m.terrainSoundAddend, m.marioObj.header.gfx.cameraToObject)
+        play_sound(SOUND_MOVING_TERRAIN_SLIDE + m.terrainSoundAddend, m.marioObj.gfx.cameraToObject)
         adjust_sound_for_speed(m)
         m.particleFlags |= PARTICLE_DUST
     } else {
@@ -725,7 +725,7 @@ export const act_hold_decelerating = (m) => {
 
     if (slopeClass == SURFACE_CLASS_VERY_SLIPPERY) {
         set_mario_animation(m, MARIO_ANIM_IDLE_WITH_LIGHT_OBJ)
-        play_sound(SOUND_MOVING_TERRAIN_SLIDE + m.terrainSoundAddend, m.marioObj.header.gfx.cameraToObject)
+        play_sound(SOUND_MOVING_TERRAIN_SLIDE + m.terrainSoundAddend, m.marioObj.gfx.cameraToObject)
         adjust_sound_for_speed(m)
         m.particleFlags |= PARTICLE_DUST
     } else {
@@ -805,7 +805,7 @@ const act_finish_turning_around = (m) => {
     if (is_anim_at_end(m)) 
         set_mario_action(m, ACT_WALKING, 0)
 
-    m.marioObj.header.gfx.angle[1] += 0x8000
+    m.marioObj.gfx.angle[1] += 0x8000
     return 0
 }
 
@@ -880,7 +880,7 @@ const act_side_flip_land = (m) => {
     }
 
     if (common_landing_action(m, MARIO_ANIM_SLIDEFLIP_LAND, ACT_FREEFALL) != GROUND_STEP_HIT_WALL) {
-        m.marioObj.header.gfx.angle[1] = s16(m.marioObj.header.gfx.angle[1] + 0x8000)
+        m.marioObj.gfx.angle[1] = s16(m.marioObj.gfx.angle[1] + 0x8000)
     }
 
     return 0
@@ -1054,7 +1054,7 @@ const common_slide_action = (m, endAction, airAction, animation) => {
     const pos = []
 
     vec3f_copy(pos, m.pos)
-    play_sound(SOUND_MOVING_TERRAIN_SLIDE + m.terrainSoundAddend, m.marioObj.header.gfx.cameraToObject)
+    play_sound(SOUND_MOVING_TERRAIN_SLIDE + m.terrainSoundAddend, m.marioObj.gfx.cameraToObject)
 
     adjust_sound_for_speed(m)
 
@@ -1062,7 +1062,7 @@ const common_slide_action = (m, endAction, airAction, animation) => {
         case GROUND_STEP_LEFT_GROUND:
             set_mario_action(m, airAction, 0)
             if (m.forwardVel < -50.0 || 50.0 < m.forwardVel) {
-                play_sound(SOUND_MARIO_HOOHOO, m.marioObj.header.gfx.cameraToObject)
+                play_sound(SOUND_MARIO_HOOHOO, m.marioObj.gfx.cameraToObject)
             }
             break
 
@@ -1171,15 +1171,15 @@ const push_or_sidle_wall = (m, startPos) => {
             set_mario_anim_with_accel(m, MARIO_ANIM_SIDESTEP_LEFT, val04)
         }
 
-        if (m.marioObj.header.gfx.unk38.animFrame < 20) {
-            play_sound(SOUND_MOVING_TERRAIN_SLIDE + m.terrainSoundAddend, m.marioObj.header.gfx.cameraToObject)
+        if (m.marioObj.gfx.unk38.animFrame < 20) {
+            play_sound(SOUND_MOVING_TERRAIN_SLIDE + m.terrainSoundAddend, m.marioObj.gfx.cameraToObject)
             m.particleFlags |= PARTICLE_DUST
         }
 
         m.actionState = 1
         m.actionArg = s16(wallAngle + 0x8000)
-        m.marioObj.header.gfx.angle[1] = s16(wallAngle + 0x8000)
-        m.marioObj.header.gfx.angle[2] = find_floor_slope(m, 0x4000)
+        m.marioObj.gfx.angle[1] = s16(wallAngle + 0x8000)
+        m.marioObj.gfx.angle[2] = find_floor_slope(m, 0x4000)
     }
 }
 
@@ -1498,7 +1498,7 @@ const act_slide_kick_slide = (m) => {
             break
     }
 
-    play_sound(SOUND_MOVING_TERRAIN_SLIDE + m.terrainSoundAddend, m.marioObj.header.gfx.cameraToObject);
+    play_sound(SOUND_MOVING_TERRAIN_SLIDE + m.terrainSoundAddend, m.marioObj.gfx.cameraToObject);
     m.particleFlags |= PARTICLE_DUST
     return 0
 }
@@ -1579,7 +1579,7 @@ export const act_hard_backward_ground_kb = (m) => {
     }
 
     if (animFrame == 54 && m.prevAction == ACT_SPECIAL_DEATH_EXIT) {
-        play_sound(SOUND_MARIO_MAMA_MIA, m.marioObj.header.gfx.cameraToObject)
+        play_sound(SOUND_MARIO_MAMA_MIA, m.marioObj.gfx.cameraToObject)
     }
 
     if (animFrame == 69) {
@@ -1612,7 +1612,7 @@ const act_death_exit_land = (m) => {
     animFrame = set_mario_animation(m, MARIO_ANIM_FALL_OVER_BACKWARDS)
 
     if (animFrame == 54) {
-        play_sound(SOUND_MARIO_MAMA_MIA, m.marioObj.header.gfx.cameraToObject);
+        play_sound(SOUND_MARIO_MAMA_MIA, m.marioObj.gfx.cameraToObject);
     }
     if (animFrame == 68) {
         play_mario_landing_sound(m, SOUND_ACTION_TERRAIN_LANDING)

--- a/src/game/MarioActionsObject.js
+++ b/src/game/MarioActionsObject.js
@@ -112,7 +112,7 @@ export const mario_update_punch_sequence = (m) => {
 
     switch (m.actionArg) {
         case 0:
-            play_sound(SOUND_MARIO_PUNCH_YAH, m.marioObj.header.gfx.cameraToObject)
+            play_sound(SOUND_MARIO_PUNCH_YAH, m.marioObj.gfx.cameraToObject)
             // Fall-through:
         case 1:
             set_mario_animation(m, MARIO_ANIM_FIRST_PUNCH)
@@ -122,7 +122,7 @@ export const mario_update_punch_sequence = (m) => {
                 m.actionArg = 1
             }
 
-            if (m.marioObj.header.gfx.unk38.animFrame >= 2) {
+            if (m.marioObj.gfx.unk38.animFrame >= 2) {
                 if (mario_check_object_grab(m)) {
                    return 1
                 }
@@ -137,7 +137,7 @@ export const mario_update_punch_sequence = (m) => {
         case 2:
             set_mario_animation(m, MARIO_ANIM_FIRST_PUNCH_FAST)
 
-            if (m.marioObj.header.gfx.unk38.animFrame <= 0) {
+            if (m.marioObj.gfx.unk38.animFrame <= 0) {
                 m.flags |= MARIO_PUNCHING
             }
 
@@ -151,7 +151,7 @@ export const mario_update_punch_sequence = (m) => {
             break
 
         case 3:
-            play_sound(SOUND_MARIO_PUNCH_WAH, m.marioObj.header.gfx.cameraToObject)
+            play_sound(SOUND_MARIO_PUNCH_WAH, m.marioObj.gfx.cameraToObject)
             // Fall-through:
         case 4:
             set_mario_animation(m, MARIO_ANIM_SECOND_PUNCH)
@@ -159,7 +159,7 @@ export const mario_update_punch_sequence = (m) => {
                 m.actionArg = 5
             } else { m.actionArg = 4 }
 
-            if (m.marioObj.header.gfx.unk38.animFrame > 0) {
+            if (m.marioObj.gfx.unk38.animFrame > 0) {
                 m.flags |= MARIO_PUNCHING
             }
 
@@ -170,7 +170,7 @@ export const mario_update_punch_sequence = (m) => {
 
         case 5:
             set_mario_animation(m, MARIO_ANIM_SECOND_PUNCH_FAST)
-            if (m.marioObj.header.gfx.unk38.animFrame <= 0) {
+            if (m.marioObj.gfx.unk38.animFrame <= 0) {
                 m.flags |= MARIO_PUNCHING
             }
 
@@ -202,7 +202,7 @@ export const mario_update_punch_sequence = (m) => {
         case 9:
             play_mario_action_sound(m, SOUND_MARIO_PUNCH_HOO, 1)
             set_mario_animation(m, MARIO_ANIM_BREAKDANCE)
-            animFrame = m.marioObj.header.gfx.unk38.animFrame
+            animFrame = m.marioObj.gfx.unk38.animFrame
 
             if (animFrame >= 2 && animFrame < 8) {
                 m.flags |= MARIO_TRIPPING
@@ -381,7 +381,7 @@ const act_picking_up_bowser = (m) => {
         m.angleVel[1] = 0
         m.marioBodyState.grabPos = GRAB_POS_BOWSER
         mario_grab_used_object(m)
-        play_sound(SOUND_MARIO_HRMM, m.marioObj.header.gfx.cameraToObject)
+        play_sound(SOUND_MARIO_HRMM, m.marioObj.gfx.cameraToObject)
     }
 
     set_mario_animation(m, MARIO_ANIM_GRAB_BOWSER)
@@ -398,9 +398,9 @@ const act_holding_bowser = (m) => {
 
     if (m.input & INPUT_B_PRESSED) {
         if (m.angleVel[1] <= -0xE00 || m.angleVel[1] >= 0xE00) {
-            play_sound(SOUND_MARIO_SO_LONGA_BOWSER, m.marioObj.header.gfx.cameraToObject)
+            play_sound(SOUND_MARIO_SO_LONGA_BOWSER, m.marioObj.gfx.cameraToObject)
         } else {
-            play_sound(SOUND_MARIO_HERE_WE_GO, m.marioObj.header.gfx.cameraToObject)
+            play_sound(SOUND_MARIO_HERE_WE_GO, m.marioObj.gfx.cameraToObject)
         }
         return set_mario_action(m, ACT_RELEASING_BOWSER, 0)
     }
@@ -452,17 +452,17 @@ const act_holding_bowser = (m) => {
 
       // play sound on overflow
     if (m.angleVel[1] <= -0x100 && spin < m.faceAngle[1]) {
-        play_sound(SOUND_OBJ_BOWSER_SPINNING, m.marioObj.header.gfx.cameraToObject)
+        play_sound(SOUND_OBJ_BOWSER_SPINNING, m.marioObj.gfx.cameraToObject)
     }
     if (m.angleVel[1] >= 0x100 && spin > m.faceAngle[1]) {
-        play_sound(SOUND_OBJ_BOWSER_SPINNING, m.marioObj.header.gfx.cameraToObject)
+        play_sound(SOUND_OBJ_BOWSER_SPINNING, m.marioObj.gfx.cameraToObject)
     }
 
     stationary_ground_step(m)
     if (m.angleVel[1] >= 0) {
-        m.marioObj.header.gfx.angle[0] = -m.angleVel[1]
+        m.marioObj.gfx.angle[0] = -m.angleVel[1]
     } else {
-        m.marioObj.header.gfx.angle[0] = m.angleVel[1]
+        m.marioObj.gfx.angle[0] = m.angleVel[1]
     }
 
     return 0

--- a/src/game/MarioActionsStationary.js
+++ b/src/game/MarioActionsStationary.js
@@ -327,7 +327,7 @@ const act_side_flip_land_stop = (m) => {
     if (check_common_landing_cancels(m, 0)) return 1
 
     landing_step(m, MARIO_ANIM_SLIDEFLIP_LAND, ACT_IDLE)
-    m.marioObj.header.gfx.angle[1] += 0x8000
+    m.marioObj.gfx.angle[1] += 0x8000
     return 0
 }
 
@@ -421,7 +421,7 @@ const act_stop_crouching = (m) => {
 }
 
 const act_backflip_land_stop = (m) => {
-    if (!(m.input & INPUT_Z_DOWN) || m.marioObj.header.gfx.unk38.animFrame >= 6) {
+    if (!(m.input & INPUT_Z_DOWN) || m.marioObj.gfx.unk38.animFrame >= 6) {
         m.input &= -3
     }
 
@@ -514,7 +514,7 @@ const act_butt_slide_stop = (m) => {
 
     stopping_step(m, MARIO_ANIM_STOP_SLIDE, ACT_IDLE)
 
-    if (m.marioObj.header.gfx.unk38.animFrame == 6) {
+    if (m.marioObj.gfx.unk38.animFrame == 6) {
         //play landing sound
     }
 

--- a/src/game/MarioActionsSubmerged.js
+++ b/src/game/MarioActionsSubmerged.js
@@ -23,16 +23,16 @@ const sWaterCurrentSpeed = [28, 12, 8, 4]
 const update_water_pitch = (m) => {
     const marioObj = m.marioObj
 
-    if (marioObj.header.gfx.angle[0] > 0) {
-        marioObj.header.gfx.pos[1] += 60.0 * sins(marioObj.header.gfx.angle[0]) * sins(marioObj.header.gfx.angle[0])
+    if (marioObj.gfx.angle[0] > 0) {
+        marioObj.gfx.pos[1] += 60.0 * sins(marioObj.gfx.angle[0]) * sins(marioObj.gfx.angle[0])
     }
 
-    if (marioObj.header.gfx.angle[0] < 0) {
-        marioObj.header.gfx.angle[0] = (marioObj.header.gfx.angle[0] * 6) / 10
+    if (marioObj.gfx.angle[0] < 0) {
+        marioObj.gfx.angle[0] = (marioObj.gfx.angle[0] * 6) / 10
     }
 
-    if (marioObj.header.gfx.angle[0] > 0) {
-        marioObj.header.gfx.angle[0] = (marioObj.header.gfx.angle[0] * 10) / 8
+    if (marioObj.gfx.angle[0] > 0) {
+        marioObj.gfx.angle[0] = (marioObj.gfx.angle[0] * 10) / 8
     }
 }
 
@@ -145,7 +145,7 @@ const set_swimming_at_surface_particles = (m, particleFlag) => {
     if (atSurface) {
         m.particleFlags |= particleFlag
         /*TODO if (atSurface ^ sWasAtSurface) {
-            play_sound(SOUND_ACTION_UNKNOWN431, m.marioObj.header.gfx.cameraToObject);
+            play_sound(SOUND_ACTION_UNKNOWN431, m.marioObj.gfx.cameraToObject);
         }*/
     }
 
@@ -199,9 +199,9 @@ const act_water_plunge = (m) => {
     stepResult = perform_water_step(m)
 
     if (m.actionState === 0) {
-        /* TODO play_sound(SOUND_ACTION_UNKNOWN430, m.marioObj.header.gfx.cameraToObject);
+        /* TODO play_sound(SOUND_ACTION_UNKNOWN430, m.marioObj.gfx.cameraToObject);
          if (m.peakHeight - m.pos[1] > 1150.0) {
-            play_sound(SOUND_MARIO_HAHA_2, m.marioObj.header.gfx.cameraToObject);
+            play_sound(SOUND_MARIO_HAHA_2, m.marioObj.gfx.cameraToObject);
         }*/
 
         m.particleFlags |= Particles.PARTICLE_WATER_SPLASH
@@ -323,8 +323,8 @@ const perform_water_step = (m) => {
 
     stepResult = perform_water_full_step(m, nextPos)
 
-    vec3f_copy(marioObj.header.gfx.pos, m.pos)
-    vec3s_set(marioObj.header.gfx.angle, -m.faceAngle[0], m.faceAngle[1], m.faceAngle[2])
+    vec3f_copy(marioObj.gfx.pos, m.pos)
+    vec3s_set(marioObj.gfx.angle, -m.faceAngle[0], m.faceAngle[1], m.faceAngle[2])
 
     return stepResult
 }
@@ -434,7 +434,7 @@ const act_drowning = (m) => {
         case 1:
             Mario.set_mario_animation(m, Mario.MARIO_ANIM_DROWNING_PART2)
             // TODO m.marioBodyState.eyeState = Mario.MARIO_EYES_DEAD;
-            if (m.marioObj.header.gfx.animInfo.animFrame == 30) {
+            if (m.marioObj.gfx.animInfo.animFrame == 30) {
                 // TODO level_trigger_warp(m, WARP_OP_DEATH);
             }
             break
@@ -589,7 +589,7 @@ const act_breaststroke = (m) => {
 
     if (m.actionTimer == 1) {
         /* TODO play_sound(sSwimStrength === MIN_SWIM_STRENGTH ? SOUND_ACTION_SWIM : SOUND_ACTION_SWIM_FAST,
-                   m.marioObj.header.gfx.cameraToObject);*/
+                   m.marioObj.gfx.cameraToObject);*/
         reset_float_globals(m)
     }
 
@@ -648,7 +648,7 @@ const float_surface_gfx = (m) => {
     if (sBounceIncrement != 0 && m.pos[1] > m.waterLevel - 85 && m.faceAngle[0] >= 0) {
         sBounceAngle = s16(sBounceAngle + sBounceIncrement)
         if (sBounceAngle >= 0) {
-            m.marioObj.header.gfx.pos[1] += sBounceMult * sins(sBounceAngle)
+            m.marioObj.gfx.pos[1] += sBounceMult * sins(sBounceAngle)
             return
         }
     }
@@ -692,7 +692,7 @@ const act_hold_water_action_end = (m) => {
 
 const act_water_shocked = (m) => {
     //TODO play_sound_if_no_flag(m, SOUND_MARIO_WAAAOOOW, MARIO_ACTION_SOUND_PLAYED);
-    //TODO play_sound(SOUND_MOVING_SHOCKED, m.marioObj.header.gfx.cameraToObject);
+    //TODO play_sound(SOUND_MOVING_SHOCKED, m.marioObj.gfx.cameraToObject);
     Camera.set_camera_shake_from_hit(CAMERA.SHAKE_SHOCK)
 
     if (Mario.set_mario_animation(m, Mario.MARIO_ANIM_SHOCKED) == 0) {

--- a/src/game/MarioMisc.js
+++ b/src/game/MarioMisc.js
@@ -152,14 +152,14 @@ class MarioMisc {
     geo_move_mario_part_from_parent(callContext, node, mtx) {
         if (callContext == GEO_CONTEXT_RENDER) {
             const gMarioObject = gLinker.ObjectListProcessor.gMarioObject
-            const gCurGraphNodeObject = gLinker.GeoRenderer.gCurGraphNodeObject.wrapperObjectNode.wrapperObject
             const gCurGraphNodeCamera = gLinker.GeoRenderer.gCurGraphNodeCamera
+            const obj = gLinker.GeoRenderer.gCurGraphNodeObject.object
             const xfm = Mat4()
 
-            if (gCurGraphNodeObject == gMarioObject && gCurGraphNodeObject.prevObj != null) {
+            if (obj == gMarioObject && obj.prevObj) {
                 create_transformation_from_matrices(xfm, mtx, gCurGraphNodeCamera.matrixPtr)
-                obj_update_pos_from_parent_transformation(xfm, gCurGraphNodeObject.prevObj)
-                obj_set_gfx_pos_from_pos(gCurGraphNodeObject.prevObj)
+                obj_update_pos_from_parent_transformation(xfm, obj.prevObj)
+                obj_set_gfx_pos_from_pos(obj.prevObj)
             }
         }
         return null
@@ -315,27 +315,27 @@ class MarioMisc {
     /**
      * Geo node that updates the held object node and the HOLP.
      */
-    geo_switch_mario_hand_grab_pos(callContext, heldObj, mtx) {
+    geo_switch_mario_hand_grab_pos(callContext, node, mtx) {
         const marioState = gLinker.LevelUpdate.gMarioState
         const gCurGraphNodeCamera = gLinker.GeoRenderer.gCurGraphNodeCamera
 
         if (callContext == GEO_CONTEXT_RENDER) {
-            heldObj.objNode = null
+            node.object = null
             if (marioState.heldObj) {
-                heldObj.objNode = marioState.heldObj
+                node.object = marioState.heldObj
                 switch (this.gBodyState.grabPos) {
                     case GRAB_POS_LIGHT_OBJ:
                         if (marioState.action & ACT_FLAG_THROWING) {
-                            vec3s_set(heldObj.translation, 50, 0, 0)
+                            vec3s_set(node.translation, 50, 0, 0)
                         } else {
-                            vec3s_set(heldObj.translation, 50, 0, 110)
+                            vec3s_set(node.translation, 50, 0, 110)
                         }
                         break
                     case GRAB_POS_HEAVY_OBJ:
-                        vec3s_set(heldObj.translation, 145, -173, 180)
+                        vec3s_set(node.translation, 145, -173, 180)
                         break
                     case GRAB_POS_BOWSER:
-                        vec3s_set(heldObj.translation, 80, -270, 1260)
+                        vec3s_set(node.translation, 80, -270, 1260)
                         break
                 }
             }
@@ -371,15 +371,15 @@ class MarioMisc {
         //         geo_remove_child(&gMirrorMario.node)
         //         break
         //     case GEO_CONTEXT_RENDER:
-        //         if (mario.header.gfx.pos[0] > 1700.0) {
+        //         if (mario.gfx.pos[0] > 1700.0) {
         //               // TODO: Is this a geo layout copy or a graph node copy?
-        //             gMirrorMario.sharedChild = mario.header.gfx.sharedChild
-        //             gMirrorMario.areaIndex = mario.header.gfx.areaIndex
-        //             vec3s_copy(gMirrorMario.angle, mario.header.gfx.angle)
-        //             vec3f_copy(gMirrorMario.pos, mario.header.gfx.pos)
-        //             vec3f_copy(gMirrorMario.scale, mario.header.gfx.scale)
+        //             gMirrorMario.sharedChild = mario.gfx.sharedChild
+        //             gMirrorMario.areaIndex = mario.gfx.areaIndex
+        //             vec3s_copy(gMirrorMario.angle, mario.gfx.angle)
+        //             vec3f_copy(gMirrorMario.pos, mario.gfx.pos)
+        //             vec3f_copy(gMirrorMario.scale, mario.gfx.scale)
 
-        //             gMirrorMario.animInfo = mario.header.gfx.animInfo
+        //             gMirrorMario.animInfo = mario.gfx.animInfo
         //             mirroredX = MIRROR_X - gMirrorMario.pos[0]
         //             gMirrorMario.pos[0] = mirroredX + MIRROR_X
         //             gMirrorMario.angle[1] = -gMirrorMario.angle[1]

--- a/src/game/MarioStep.js
+++ b/src/game/MarioStep.js
@@ -60,9 +60,9 @@ export const mario_bonk_reflection = (m, negateSpeed) => {
         const wallAngle = atan2s(m.wall.normal.z, m.wall.normal.x)
         m.faceAngle[1] = s16(wallAngle - s16(m.faceAngle[1] - wallAngle))
         play_sound((m.flags & Mario.MARIO_METAL_CAP) ? SOUND_ACTION_METAL_BONK : SOUND_ACTION_BONK,
-                   m.marioObj.header.gfx.cameraToObject)
+                   m.marioObj.gfx.cameraToObject)
     } else {
-        play_sound(SOUND_ACTION_HIT, m.marioObj.header.gfx.cameraToObject);
+        play_sound(SOUND_ACTION_HIT, m.marioObj.gfx.cameraToObject);
     }
 
     if (negateSpeed) {
@@ -96,8 +96,8 @@ export const stop_and_set_height_to_floor = (m) => {
 
     m.pos[1] = m.floorHeight
 
-    marioObj.header.gfx.pos = [...m.pos]
-    marioObj.header.gfx.angle = [0, m.faceAngle[1], 0]
+    marioObj.gfx.pos = [...m.pos]
+    marioObj.gfx.angle = [0, m.faceAngle[1], 0]
 }
 
 const check_ledge_grab = (m, wall, intendedPos, nextPos) => {
@@ -294,8 +294,8 @@ export const perform_air_step = (m, stepArg) => {
     }
     apply_vertical_wind(m)
 
-    vec3f_copy(m.marioObj.header.gfx.pos, m.pos)
-    vec3s_set(m.marioObj.header.gfx.angle, 0, m.faceAngle[1], 0)
+    vec3f_copy(m.marioObj.gfx.pos, m.pos)
+    vec3s_set(m.marioObj.gfx.angle, 0, m.faceAngle[1], 0)
 
     return stepResult
 }
@@ -370,8 +370,8 @@ export const perform_ground_step = (m) => {
     }
 
     m.terrainSoundAddend = Mario.mario_get_terrain_sound_addend(m)
-    vec3f_copy(m.marioObj.header.gfx.pos, m.pos)
-    vec3s_set(m.marioObj.header.gfx.angle, 0, m.faceAngle[1], 0)
+    vec3f_copy(m.marioObj.gfx.pos, m.pos)
+    vec3s_set(m.marioObj.gfx.angle, 0, m.faceAngle[1], 0)
 
     if (stepResult == Mario.GROUND_STEP_HIT_WALL_CONTINUE_QSTEPS) {
         stepResult = Mario.GROUND_STEP_HIT_WALL
@@ -386,8 +386,8 @@ export const stationary_ground_step = (m) => {
 
     m.pos[1] = m.floorHeight
 
-    m.marioObj.header.gfx.pos = [...m.pos]
-    m.marioObj.header.gfx.angle = [0, m.faceAngle[1], 0]
+    m.marioObj.gfx.pos = [...m.pos]
+    m.marioObj.gfx.angle = [0, m.faceAngle[1], 0]
 
     return 0
 }

--- a/src/game/ObjBehaviors.js
+++ b/src/game/ObjBehaviors.js
@@ -19,9 +19,9 @@ export let sObjFloor
 export let sOrientObjWithFloor = 1
 
 export const is_point_within_radius_of_mario = (x, y, z, dist) => {
-    const mGfxX = ObjectListProc.gMarioObject.header.gfx.pos[0]
-    const mGfxY = ObjectListProc.gMarioObject.header.gfx.pos[1]
-    const mGfxZ = ObjectListProc.gMarioObject.header.gfx.pos[2]
+    const mGfxX = ObjectListProc.gMarioObject.gfx.pos[0]
+    const mGfxY = ObjectListProc.gMarioObject.gfx.pos[1]
+    const mGfxZ = ObjectListProc.gMarioObject.gfx.pos[2]
 
     if ((x - mGfxX) * (x - mGfxX) + (y - mGfxY) * (y - mGfxY) + (z - mGfxZ) * (z - mGfxZ) < dist * dist) {
         return 1
@@ -88,9 +88,9 @@ export const curr_obj_random_blink = (blinkTimer) => {
  */
 export const set_object_visibility = (obj, dist) => {
     if (is_point_within_radius_of_mario(obj.rawData[oPosX], obj.rawData[oPosY], obj.rawData[oPosZ], dist) == 1) {
-        obj.header.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
+        obj.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
     } else {
-        obj.header.gfx.flags |= GRAPH_RENDER_INVISIBLE
+        obj.gfx.flags |= GRAPH_RENDER_INVISIBLE
     }
 }
 
@@ -187,7 +187,7 @@ export const obj_orient_graph = (obj, normalX, normalY, normalZ) => {
     if (sOrientObjWithFloor == 0) return
 
     // Passes on orienting billboard objects, i.e. coins, trees, etc.
-    if ((obj.header.gfx.flags & GRAPH_RENDER_BILLBOARD) != 0) return
+    if ((obj.gfx.flags & GRAPH_RENDER_BILLBOARD) != 0) return
 
     const throwMatrix = new Array(4).fill(0).map(() => new Array(4).fill(0))
 
@@ -200,7 +200,7 @@ export const obj_orient_graph = (obj, normalX, normalY, normalZ) => {
     surfaceNormals[2] = normalZ
 
     mtxf_align_terrain_normal(throwMatrix, surfaceNormals, objVisualPosition, obj.rawData[oFaceAngleYaw])
-    obj.header.gfx.throwMatrix = throwMatrix
+    obj.gfx.throwMatrix = throwMatrix
 }
 
 export const calc_obj_friction = (objFrictionWrapper, floor_nY) => {
@@ -381,9 +381,9 @@ export const obj_flicker_and_disappear = (obj, lifeSpan) => {
     if (obj.rawData[oTimer] < lifeSpan + 40) {
 
         if (obj.rawData[oTimer] % 2 != 0) {
-            obj.header.gfx.flags |= GRAPH_RENDER_INVISIBLE
+            obj.gfx.flags |= GRAPH_RENDER_INVISIBLE
         } else {
-            obj.header.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
+            obj.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
         }
 
     } else {

--- a/src/game/ObjBehaviors2.js
+++ b/src/game/ObjBehaviors2.js
@@ -179,11 +179,11 @@ export const obj_set_hitbox = (obj, hitbox) => {
         cur_obj_become_tangible()
     }
 
-    obj.hitboxRadius = obj.header.gfx.scale[0] * hitbox.radius
-    obj.hitboxHeight = obj.header.gfx.scale[1] * hitbox.height
-    obj.hurtboxRadius = obj.header.gfx.scale[0] * hitbox.hurtboxRadius
-    obj.hurtboxHeight = obj.header.gfx.scale[1] * hitbox.hurtboxHeight
-    obj.hitboxDownOffset = obj.header.gfx.scale[1] * hitbox.downOffset
+    obj.hitboxRadius = obj.gfx.scale[0] * hitbox.radius
+    obj.hitboxHeight = obj.gfx.scale[1] * hitbox.height
+    obj.hurtboxRadius = obj.gfx.scale[0] * hitbox.hurtboxRadius
+    obj.hurtboxHeight = obj.gfx.scale[1] * hitbox.hurtboxHeight
+    obj.hitboxDownOffset = obj.gfx.scale[1] * hitbox.downOffset
 }
 
 export const obj_bounce_off_walls_edges_objects = (targetYawWrapper) => {
@@ -304,7 +304,7 @@ export const obj_act_knockback = () => {
 
     cur_obj_update_floor_and_walls()
 
-    if (o.header.gfx.unk38.curAnim) {
+    if (o.gfx.unk38.curAnim) {
         cur_obj_extend_animation_if_at_end()
     }
 
@@ -324,14 +324,14 @@ export const obj_act_squished = (baseScale) => {
 
     const o = ObjectListProc.gCurrentObject
 
-    if (o.header.gfx.unk38.curAnim) {
+    if (o.gfx.unk38.curAnim) {
         cur_obj_extend_animation_if_at_end()
     }
 
-    const result = approach_number_ptr(o.header.gfx.scale, 1, targetScaleY, baseScale * 0.14)
+    const result = approach_number_ptr(o.gfx.scale, 1, targetScaleY, baseScale * 0.14)
     if (result) {
-        o.header.gfx.scale[0] = baseScale * 2.0 - o.header.gfx.scale[1]
-        o.header.gfx.scale[2] = baseScale * 2.0 - o.header.gfx.scale[1]
+        o.gfx.scale[0] = baseScale * 2.0 - o.gfx.scale[1]
+        o.gfx.scale[2] = baseScale * 2.0 - o.gfx.scale[1]
 
         if (o.rawData[oTimer] >= 16) {
             obj_die_if_health_non_positive()

--- a/src/game/ObjectCollisions.js
+++ b/src/game/ObjectCollisions.js
@@ -8,16 +8,17 @@ import { oIntangibleTimer, oPosY, oPosX, oPosZ, oInteractType, oInteractionSubty
 import { INT_SUBTYPE_DELAY_INVINCIBILITY } from "./Interaction"
 
 
-const clear_object_collision = (startNode) => {
-    let sp4 = startNode.next
+const clear_object_collision = (listHead) => {
+    let obj = listHead.next
 
-    while (sp4 != startNode) {
-        const obj = sp4.wrapperObject
+    while (obj != listHead) {
         obj.collidedObjs = []
         obj.numCollidedObjs = 0 // possibly not necessary
         obj.collidedObjInteractTypes = 0
-        if (obj.rawData[oIntangibleTimer] > 0) obj.rawData[oIntangibleTimer]--
-        sp4 = sp4.next
+        if (obj.rawData[oIntangibleTimer] > 0) {
+            obj.rawData[oIntangibleTimer]--
+        }
+        obj = obj.next
     }
 }
 
@@ -82,67 +83,68 @@ const detect_object_hurtbox_overlap = (a, b) => {
 
 
 
-const check_collision_in_list = (aObj, b, c) => {
+const check_collision_in_list = (aObj, listHead, bObj) => {
     if (aObj.rawData[oIntangibleTimer] == 0) {
-        while (b != c) {
-            const bObj = b.wrapperObject
+        bObj ||= listHead.next
+        while (bObj != listHead) {
             if (bObj.rawData[oIntangibleTimer] == 0) {
                 if (detect_object_hitbox_overlap(aObj, bObj) && bObj.hurtboxRadius != 0.0) {
                     detect_object_hurtbox_overlap(aObj, bObj)
                 }
             }
-            b = b.next
+            bObj = bObj.next
         }
     }
 }
 
 const check_player_object_collision = () => {
     const gObjectLists = ObjectListProc.gObjectLists
-    const marioObj = gObjectLists[OBJ_LIST_PLAYER].next.wrapperObject
+    const marioObj = gObjectLists[OBJ_LIST_PLAYER].next
 
-    check_collision_in_list(marioObj, gObjectLists[OBJ_LIST_POLELIKE].next,    gObjectLists[OBJ_LIST_POLELIKE])
-    check_collision_in_list(marioObj, gObjectLists[OBJ_LIST_LEVEL].next,       gObjectLists[OBJ_LIST_LEVEL])
-    check_collision_in_list(marioObj, gObjectLists[OBJ_LIST_GENACTOR].next,    gObjectLists[OBJ_LIST_GENACTOR])
-    check_collision_in_list(marioObj, gObjectLists[OBJ_LIST_PUSHABLE].next,    gObjectLists[OBJ_LIST_PUSHABLE])
-    check_collision_in_list(marioObj, gObjectLists[OBJ_LIST_SURFACE].next,     gObjectLists[OBJ_LIST_SURFACE])
-    check_collision_in_list(marioObj, gObjectLists[OBJ_LIST_DESTRUCTIVE].next, gObjectLists[OBJ_LIST_DESTRUCTIVE])
+    check_collision_in_list(marioObj, gObjectLists[OBJ_LIST_POLELIKE])
+    check_collision_in_list(marioObj, gObjectLists[OBJ_LIST_LEVEL])
+    check_collision_in_list(marioObj, gObjectLists[OBJ_LIST_GENACTOR])
+    check_collision_in_list(marioObj, gObjectLists[OBJ_LIST_PUSHABLE])
+    check_collision_in_list(marioObj, gObjectLists[OBJ_LIST_SURFACE])
+    check_collision_in_list(marioObj, gObjectLists[OBJ_LIST_DESTRUCTIVE])
 }
 
 const check_destructive_object_collision = () => {
-    const headObj = ObjectListProc.gObjectLists[OBJ_LIST_DESTRUCTIVE]
-    let objNode = headObj.next
+    const gObjectLists = ObjectListProc.gObjectLists
+    const listHead = gObjectLists[OBJ_LIST_DESTRUCTIVE]
+    let obj = listHead.next
 
-    while (objNode != headObj) {
-        const obj = objNode.wrapperObject
+    while (obj != listHead) {
         if (obj.rawData[oDistanceToMario] < 2000 && !(obj.activeFlags & ACTIVE_FLAG_UNK9)) {
-            check_collision_in_list(obj, objNode.next, headObj)
-            check_collision_in_list(obj, ObjectListProc.gObjectLists[OBJ_LIST_GENACTOR].next, ObjectListProc.gObjectLists[OBJ_LIST_GENACTOR])
-            check_collision_in_list(obj, ObjectListProc.gObjectLists[OBJ_LIST_PUSHABLE].next, ObjectListProc.gObjectLists[OBJ_LIST_PUSHABLE])
-            check_collision_in_list(obj, ObjectListProc.gObjectLists[OBJ_LIST_SURFACE].next, ObjectListProc.gObjectLists[OBJ_LIST_SURFACE])
+            check_collision_in_list(obj, listHead, obj.next)
+            check_collision_in_list(obj, gObjectLists[OBJ_LIST_GENACTOR])
+            check_collision_in_list(obj, gObjectLists[OBJ_LIST_PUSHABLE])
+            check_collision_in_list(obj, gObjectLists[OBJ_LIST_SURFACE])
         }
-        objNode = objNode.next
+        obj = obj.next
     }
 }
 
 const check_pushable_object_collision = () => {
-    const headObj = ObjectListProc.gObjectLists[OBJ_LIST_PUSHABLE]
-    let objNode = headObj.next
+    const gObjectLists = ObjectListProc.gObjectLists
+    const listHead = gObjectLists[OBJ_LIST_PUSHABLE]
+    let obj = listHead.next
 
-    while (objNode != headObj) {
-        const obj = objNode.wrapperObject
-        check_collision_in_list(obj, objNode.next, headObj)
-        objNode = objNode.next
+    while (obj != listHead) {
+        check_collision_in_list(obj, listHead, obj.next)
+        obj = obj.next
     }
 }
 
 export const detect_object_collisions = () => {
-    clear_object_collision(ObjectListProc.gObjectLists[OBJ_LIST_POLELIKE])
-    clear_object_collision(ObjectListProc.gObjectLists[OBJ_LIST_PLAYER])
-    clear_object_collision(ObjectListProc.gObjectLists[OBJ_LIST_PUSHABLE])
-    clear_object_collision(ObjectListProc.gObjectLists[OBJ_LIST_GENACTOR])
-    clear_object_collision(ObjectListProc.gObjectLists[OBJ_LIST_LEVEL])
-    clear_object_collision(ObjectListProc.gObjectLists[OBJ_LIST_SURFACE])
-    clear_object_collision(ObjectListProc.gObjectLists[OBJ_LIST_DESTRUCTIVE])
+    const gObjectLists = ObjectListProc.gObjectLists
+    clear_object_collision(gObjectLists[OBJ_LIST_POLELIKE])
+    clear_object_collision(gObjectLists[OBJ_LIST_PLAYER])
+    clear_object_collision(gObjectLists[OBJ_LIST_PUSHABLE])
+    clear_object_collision(gObjectLists[OBJ_LIST_GENACTOR])
+    clear_object_collision(gObjectLists[OBJ_LIST_LEVEL])
+    clear_object_collision(gObjectLists[OBJ_LIST_SURFACE])
+    clear_object_collision(gObjectLists[OBJ_LIST_DESTRUCTIVE])
     check_player_object_collision()
     check_pushable_object_collision()
     check_destructive_object_collision()

--- a/src/game/ObjectHelpers.js
+++ b/src/game/ObjectHelpers.js
@@ -100,13 +100,13 @@ export const cur_obj_lateral_dist_to_home = () => {
 export const cur_obj_set_model = (modelID) => {
     const o = ObjectListProc.gCurrentObject
 
-    o.header.gfx.sharedChild = gLinker.Area.gLoadedGraphNodes[modelID]
+    o.gfx.sharedChild = gLinker.Area.gLoadedGraphNodes[modelID]
 }
 
 export const cur_obj_has_model = (modelID) => {
     const o = ObjectListProc.gCurrentObject
 
-    if (o.header.gfx.sharedChild == gLinker.Area.gLoadedGraphNodes[modelID]) {
+    if (o.gfx.sharedChild == gLinker.Area.gLoadedGraphNodes[modelID]) {
         return 1
     } else {
         return 0
@@ -139,10 +139,10 @@ export const cur_obj_set_pos_relative = (other, dleft, dy, dforward) => {
 
 export const geo_switch_anim_state = (callerContext, node) => {
     if (callerContext == GEO_CONTEXT_RENDER) {
-        let obj = GeoRenderer.gCurGraphNodeObject.wrapperObjectNode.wrapperObject
+        let obj = GeoRenderer.gCurGraphNodeObject.object
 
         if (GeoRenderer.gCurGraphNodeHeldObject) {
-            obj = GeoRenderer.gCurGraphNodeHeldObject.objNode
+            obj = GeoRenderer.gCurGraphNodeHeldObject.object
         }
 
         // if the case is greater than the number of cases, set to 0 to aexport const ove = rin=> g
@@ -188,10 +188,10 @@ export const geo_update_layer_transparency = (callerContext, node) => {
     const dl = []
 
     if (callerContext == GEO_CONTEXT_RENDER) {
-        let obj = GeoRenderer.gCurGraphNodeObject.wrapperObjectNode.wrapperObject
+        let obj = GeoRenderer.gCurGraphNodeObject.object
 
         if (GeoRenderer.gCurGraphNodeHeldObject) {
-            obj = GeoRenderer.gCurGraphNodeHeldObject.objNode
+            obj = GeoRenderer.gCurGraphNodeHeldObject.object
         }
 
         const opacity = obj.rawData[oOpacity]
@@ -265,7 +265,7 @@ export const spawn_water_droplet = (parent, params) => {
     randomScale = random_float() * params.randSize[1] + params.randSize[0]
     obj_scale(newObj, randomScale)
 
-    newObj.header.gfx.bleh = "water droplet"
+    newObj.gfx.bleh = "water droplet"
     return newObj
 }
 
@@ -273,10 +273,10 @@ export const spawn_object_at_origin = (parent, model, behavior) => {
     const obj = gLinker.Spawn.create_object(behavior)
 
     obj.parentObj = parent
-    obj.header.gfx.areaIndex = parent.header.gfx.areaIndex
-    obj.header.gfx.activeAreaIndex = parent.header.gfx.areaIndex
+    obj.gfx.areaIndex = parent.gfx.areaIndex
+    obj.gfx.activeAreaIndex = parent.gfx.areaIndex
 
-    geo_obj_init(obj.header.gfx, gLinker.Area.gLoadedGraphNodes[model], [0,0,0], [0,0,0])
+    geo_obj_init(obj.gfx, gLinker.Area.gLoadedGraphNodes[model], [0,0,0], [0,0,0])
 
     return obj
 }
@@ -292,7 +292,7 @@ export const spawn_object_abs_with_rot = (parent, model, behavior, x, y, z, rx, 
 export const cur_obj_check_anim_frame = (frame) => {
     const o = ObjectListProc.gCurrentObject
 
-    const animFrame = o.header.gfx.unk38.animFrame
+    const animFrame = o.gfx.unk38.animFrame
     if (animFrame == frame) {
         return 1
     } else {
@@ -302,7 +302,7 @@ export const cur_obj_check_anim_frame = (frame) => {
 
 export const cur_obj_check_anim_frame_in_range = (startFrame, rangeLength) => {
     const o = ObjectListProc.gCurrentObject
-    let /*s32*/ animFrame = o.header.gfx.unk38.animFrame
+    let /*s32*/ animFrame = o.gfx.unk38.animFrame
 
     if (animFrame >= startFrame && animFrame < startFrame + rangeLength) {
         return 1
@@ -313,7 +313,7 @@ export const cur_obj_check_anim_frame_in_range = (startFrame, rangeLength) => {
 
 // export const cur_obj_check_frame_prior_current_frame = (a0) => {
 //     const o = ObjectListProc.gCurrentObject
-//     let /*s16*/ sp6 = o.header.gfx.unk38.animFrame
+//     let /*s16*/ sp6 = o.gfx.unk38.animFrame
 
 //     while (*a0 != -1) {
 //         if (*a0 == sp6) {
@@ -427,19 +427,19 @@ export const obj_update_pos_from_parent_transformation = (a0, a1) => {
 }
 
 export const obj_apply_scale_to_matrix = (obj, dst, src) => {
-    dst[0][0] = src[0][0] * obj.header.gfx.scale[0]
-    dst[1][0] = src[1][0] * obj.header.gfx.scale[1]
-    dst[2][0] = src[2][0] * obj.header.gfx.scale[2]
+    dst[0][0] = src[0][0] * obj.gfx.scale[0]
+    dst[1][0] = src[1][0] * obj.gfx.scale[1]
+    dst[2][0] = src[2][0] * obj.gfx.scale[2]
     dst[3][0] = src[3][0]
 
-    dst[0][1] = src[0][1] * obj.header.gfx.scale[0]
-    dst[1][1] = src[1][1] * obj.header.gfx.scale[1]
-    dst[2][1] = src[2][1] * obj.header.gfx.scale[2]
+    dst[0][1] = src[0][1] * obj.gfx.scale[0]
+    dst[1][1] = src[1][1] * obj.gfx.scale[1]
+    dst[2][1] = src[2][1] * obj.gfx.scale[2]
     dst[3][1] = src[3][1]
 
-    dst[0][2] = src[0][2] * obj.header.gfx.scale[0]
-    dst[1][2] = src[1][2] * obj.header.gfx.scale[1]
-    dst[2][2] = src[2][2] * obj.header.gfx.scale[2]
+    dst[0][2] = src[0][2] * obj.gfx.scale[0]
+    dst[1][2] = src[1][2] * obj.gfx.scale[1]
+    dst[2][2] = src[2][2] * obj.gfx.scale[2]
     dst[3][2] = src[3][2]
 
     dst[0][3] = src[0][3]
@@ -1288,7 +1288,7 @@ export const cur_obj_find_nearby_held_actor = (behavior, maxDist) => {
             }
         }
 
-        obj = obj.header.next
+        obj = obj.next
     }
 
     return foundObj
@@ -1321,28 +1321,28 @@ export const cur_obj_set_vel_from_mario_vel = (f12, f14) => {
 
 export const cur_obj_reverse_animation = () => {
     const o = ObjectListProc.gCurrentObject
-    if (o.header.gfx.unk38.animFrame >= 0) {
-        o.header.gfx.unk38.animFrame--
+    if (o.gfx.unk38.animFrame >= 0) {
+        o.gfx.unk38.animFrame--
     }
 }
 
 export const cur_obj_extend_animation_if_at_end = () => {
     const o = ObjectListProc.gCurrentObject
 
-    const sp4 = o.header.gfx.unk38.animFrame
-    const sp0 = o.header.gfx.unk38.curAnim.unk08 - 2
+    const sp4 = o.gfx.unk38.animFrame
+    const sp0 = o.gfx.unk38.curAnim.unk08 - 2
 
     if (sp4 == sp0) {
-        o.header.gfx.unk38.animFrame--
+        o.gfx.unk38.animFrame--
     }
 }
 
 
 export const cur_obj_check_if_near_animation_end = () => {
     const o = ObjectListProc.gCurrentObject
-    let animFlags = o.header.gfx.unk38.curAnim.flags
-    let animFrame = o.header.gfx.unk38.animFrame
-    let nearLoopEnd = o.header.gfx.unk38.curAnim.unk08 - 2
+    let animFlags = o.gfx.unk38.curAnim.flags
+    let animFrame = o.gfx.unk38.animFrame
+    let nearLoopEnd = o.gfx.unk38.curAnim.unk08 - 2
     let isNearEnd = 0
 
     if (animFlags & ANIM_FLAG_NOLOOP && nearLoopEnd + 1 == animFrame) {
@@ -1358,8 +1358,8 @@ export const cur_obj_check_if_near_animation_end = () => {
 
 export const cur_obj_check_if_at_animation_end = () => {
     const o = ObjectListProc.gCurrentObject
-    let animFrame = o.header.gfx.unk38.animFrame
-    let lastFrame = o.header.gfx.unk38.curAnim.unk08 - 1
+    let animFrame = o.gfx.unk38.animFrame
+    let lastFrame = o.gfx.unk38.curAnim.unk08 - 1
 
     if (animFrame == lastFrame) {
         return 1
@@ -1505,9 +1505,9 @@ export const obj_set_pos = (obj, x, y, z) => {
 }
 
 export const obj_copy_scale = (dst, src) => {
-    dst.header.gfx.scale[0] = src.header.gfx.scale[0]
-    dst.header.gfx.scale[1] = src.header.gfx.scale[1]
-    dst.header.gfx.scale[2] = src.header.gfx.scale[2]
+    dst.gfx.scale[0] = src.gfx.scale[0]
+    dst.gfx.scale[1] = src.gfx.scale[1]
+    dst.gfx.scale[2] = src.gfx.scale[2]
 }
 
 export const obj_set_parent_relative_pos = (obj, relX, relY, relZ) => {
@@ -1539,12 +1539,12 @@ export const cur_obj_within_12k_bounds = () => {
 
 export const cur_obj_enable_rendering = () => {
     const o = ObjectListProc.gCurrentObject
-    o.header.gfx.flags |= GRAPH_RENDER_ACTIVE
+    o.gfx.flags |= GRAPH_RENDER_ACTIVE
 }
 
 export const cur_obj_disable_rendering = () => {
     const o = ObjectListProc.gCurrentObject
-    o.header.gfx.flags &= ~GRAPH_RENDER_ACTIVE
+    o.gfx.flags &= ~GRAPH_RENDER_ACTIVE
 }
 
 export const cur_obj_become_tangible = () => {
@@ -1559,12 +1559,12 @@ export const cur_obj_become_intangible = () => {
 
 export const cur_obj_hide = () => {
     const o = ObjectListProc.gCurrentObject
-    o.header.gfx.flags |= GRAPH_RENDER_INVISIBLE
+    o.gfx.flags |= GRAPH_RENDER_INVISIBLE
 }
 
 export const cur_obj_unhide = () => {
     const o = ObjectListProc.gCurrentObject
-    o.header.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
+    o.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
 }
 
 export const cur_obj_clear_interact_status_flag = (flag) => {
@@ -1581,22 +1581,22 @@ export const obj_mark_for_deletion = (obj) => {
 }
 
 export const obj_scale = (obj, scale) => {
-    obj.header.gfx.scale[0] = scale
-    obj.header.gfx.scale[1] = scale
-    obj.header.gfx.scale[2] = scale
+    obj.gfx.scale[0] = scale
+    obj.gfx.scale[1] = scale
+    obj.gfx.scale[2] = scale
 }
 
 export const obj_scale_xyz = (obj, xScale, yScale, zScale) => {
-    obj.header.gfx.scale[0] = xScale
-    obj.header.gfx.scale[1] = yScale
-    obj.header.gfx.scale[2] = zScale
+    obj.gfx.scale[0] = xScale
+    obj.gfx.scale[1] = yScale
+    obj.gfx.scale[2] = zScale
 }
 
 export const cur_obj_scale = (scale) => {
     const o = ObjectListProc.gCurrentObject
-    o.header.gfx.scale[0] = scale
-    o.header.gfx.scale[1] = scale
-    o.header.gfx.scale[2] = scale
+    o.gfx.scale[0] = scale
+    o.gfx.scale[1] = scale
+    o.gfx.scale[2] = scale
 }
 
 export const obj_translate_xyz_random = (obj, rangeLength) => {
@@ -1606,21 +1606,21 @@ export const obj_translate_xyz_random = (obj, rangeLength) => {
 }
 
 export const obj_set_gfx_pos_from_pos = (obj) => {
-    obj.header.gfx.pos[0] = obj.rawData[oPosX]
-    obj.header.gfx.pos[1] = obj.rawData[oPosY]
-    obj.header.gfx.pos[2] = obj.rawData[oPosZ]
+    obj.gfx.pos[0] = obj.rawData[oPosX]
+    obj.gfx.pos[1] = obj.rawData[oPosY]
+    obj.gfx.pos[2] = obj.rawData[oPosZ]
 }
 
 export const cur_obj_init_animation = (animIndex) => {
     const o = ObjectListProc.gCurrentObject
     const anims = o.rawData[oAnimations]
-    geo_obj_init_animation(o.header.gfx, anims[animIndex]);
+    geo_obj_init_animation(o.gfx, anims[animIndex]);
 }
 
 export const cur_obj_init_animation_with_sound = (animIndex) => {
     const o = ObjectListProc.gCurrentObject
     const anims = o.rawData[oAnimations]
-    geo_obj_init_animation(o.header.gfx, anims[animIndex])
+    geo_obj_init_animation(o.gfx, anims[animIndex])
     o.rawData[oSoundStateID] = animIndex
 }
 
@@ -1628,12 +1628,12 @@ export const cur_obj_init_animation_with_accel_and_sound = (animIndex, accel) =>
     const o = ObjectListProc.gCurrentObject
     const anims = o.rawData[oAnimations]
     const animAccel = parseInt(accel * 65536.0)
-    geo_obj_init_animation_accel(o.header.gfx, anims[animIndex], animAccel)
+    geo_obj_init_animation_accel(o.gfx, anims[animIndex], animAccel)
 }
 
 export const obj_init_animation_with_sound = (obj, animations, animIndex) => {
     obj.rawData[oAnimations] = animations
-    geo_obj_init_animation(obj.header.gfx, animations[animIndex])
+    geo_obj_init_animation(obj.gfx, animations[animIndex])
     obj.rawData[oSoundStateID] = animIndex
 }
 
@@ -1666,7 +1666,6 @@ export const apply_drag_to_value = (ptr, dragStrength) => {
 
 
 export const cur_obj_apply_drag_xz = (dragStrength) => {
-
     const o = ObjectListProc.gCurrentObject
 
     const wrapper = { value: o.rawData[oVelX] }
@@ -1781,13 +1780,13 @@ export const cur_obj_wait_then_blink = (timeUntilBlinking, numBlinks) => {
     if (o.rawData[oTimer] >= timeUntilBlinking) {
         timeBlinking = o.rawData[oTimer] - timeUntilBlinking
         if (timeBlinking % 2 != 0) {
-            o.header.gfx.flags |= GRAPH_RENDER_INVISIBLE
+            o.gfx.flags |= GRAPH_RENDER_INVISIBLE
 
             if (timeBlinking / 2 > numBlinks) {
                 done = 1
             }
         } else {
-            o.header.gfx.flags &= ~ GRAPH_RENDER_INVISIBLE
+            o.gfx.flags &= ~ GRAPH_RENDER_INVISIBLE
         }
     }
 

--- a/src/game/ObjectListProcessor.js
+++ b/src/game/ObjectListProcessor.js
@@ -178,8 +178,8 @@ class ObjectListProcessor {
     update_objects_starting_at(objList, firstObj) {
         let count = 0
         while (objList != firstObj) {
-            this.gCurrentObject = firstObj.wrapperObject
-            this.gCurrentObject.header.gfx.flags |= GraphNode.GRAPH_RENDER_HAS_ANIMATION
+            this.gCurrentObject = firstObj
+            this.gCurrentObject.gfx.flags |= GraphNode.GRAPH_RENDER_HAS_ANIMATION
             gLinker.BehaviorCommands.cur_obj_update()
             firstObj = firstObj.next
             count++
@@ -191,7 +191,7 @@ class ObjectListProcessor {
         let obj = objList.next
 
         while (objList != obj) {
-            this.gCurrentObject = obj.wrapperObject
+            this.gCurrentObject = obj
             obj = obj.next
 
             if ((this.gCurrentObject.activeFlags & ACTIVE_FLAG_ACTIVE) != ACTIVE_FLAG_ACTIVE) {
@@ -258,43 +258,35 @@ class ObjectListProcessor {
         this.gCurrentObject.rawData[oPosY] = gMarioState.pos[1]
         this.gCurrentObject.rawData[oPosZ] = gMarioState.pos[2]
 
-        this.gCurrentObject.rawData[oFaceAnglePitch] = this.gCurrentObject.header.gfx.angle[0]
-        this.gCurrentObject.rawData[oFaceAngleYaw] = this.gCurrentObject.header.gfx.angle[1]
-        this.gCurrentObject.rawData[oFaceAngleRoll] = this.gCurrentObject.header.gfx.angle[2]
+        this.gCurrentObject.rawData[oFaceAnglePitch] = this.gCurrentObject.gfx.angle[0]
+        this.gCurrentObject.rawData[oFaceAngleYaw]   = this.gCurrentObject.gfx.angle[1]
+        this.gCurrentObject.rawData[oFaceAngleRoll]  = this.gCurrentObject.gfx.angle[2]
 
-        this.gCurrentObject.rawData[oMoveAnglePitch] = this.gCurrentObject.header.gfx.angle[0]
-        this.gCurrentObject.rawData[oMoveAngleYaw] = this.gCurrentObject.header.gfx.angle[1]
-        this.gCurrentObject.rawData[oMoveAngleRoll] = this.gCurrentObject.header.gfx.angle[2]
+        this.gCurrentObject.rawData[oMoveAnglePitch] = this.gCurrentObject.gfx.angle[0]
+        this.gCurrentObject.rawData[oMoveAngleYaw]   = this.gCurrentObject.gfx.angle[1]
+        this.gCurrentObject.rawData[oMoveAngleRoll]  = this.gCurrentObject.gfx.angle[2]
 
         this.gCurrentObject.rawData[oVelX] = gMarioState.vel[0]
         this.gCurrentObject.rawData[oVelY] = gMarioState.vel[1]
         this.gCurrentObject.rawData[oVelZ] = gMarioState.vel[2]
 
         this.gCurrentObject.rawData[oAngleVelPitch] = gMarioState.angleVel[0]
-        this.gCurrentObject.rawData[oAngleVelYaw] = gMarioState.angleVel[1]
-        this.gCurrentObject.rawData[oAngleVelRoll] = gMarioState.angleVel[2]
+        this.gCurrentObject.rawData[oAngleVelYaw]   = gMarioState.angleVel[1]
+        this.gCurrentObject.rawData[oAngleVelRoll]  = gMarioState.angleVel[2]
     }
 
     /**
      * Unload all objects whose activeAreaIndex is areaIndex.
      */
-    unload_objects_from_area(unused, areaIndex) {
-        let obj
-        let node
-        let listHead
-        let /*s32*/ i
-
-        for (i = 0; i < this.NUM_OBJ_LISTS; i++) {
-            listHead = this.gObjectLists[i]
-            node = listHead.next
-
-            while (node != listHead) {
-                obj = node.wrapperObject
-                node = node.next
-
-                if (obj.header.gfx.activeAreaIndex == areaIndex) {
+    unload_objects_from_area(areaIndex) {
+        for (let i = 0; i < this.NUM_OBJ_LISTS; i++) {
+            let listHead = this.gObjectLists[i]
+            let obj = listHead.next
+            while (obj != listHead) {
+                if (obj.gfx.activeAreaIndex == areaIndex) {
                     gLinker.Spawn.unload_object(obj)
                 }
+                obj = obj.next
             }
         }
     }
@@ -329,10 +321,10 @@ class ObjectListProcessor {
                     // }
                     // this.totalMarios++
                     this.gMarioObject = object
-                    GraphNode.geo_make_first_child(object.header.gfx)
+                    GraphNode.geo_make_first_child(object.gfx)
                 }
 
-                GraphNode.geo_obj_init_spawninfo(object.header.gfx, spawnInfo)
+                GraphNode.geo_obj_init_spawninfo(object.gfx, spawnInfo)
 
                 object.rawData[oPosX] = spawnInfo.startPos[0]
                 object.rawData[oPosY] = spawnInfo.startPos[1]

--- a/src/game/Shadow.js
+++ b/src/game/Shadow.js
@@ -64,8 +64,8 @@ const atan2_deg = (a, b) => {
 const correct_shadow_solidity_for_animations = (isLuigi, initialSolidity, shadow) => {
     if (ObjectListProc.gMarioObject.length > 1) throw "not implemented multiple mario shadow"
     const player = ObjectListProc.gMarioObject
-    const animFrame = player.header.gfx.unk38.animFrame
-    switch (player.header.gfx.unk38.animID) {
+    const animFrame = player.gfx.unk38.animFrame
+    switch (player.gfx.unk38.animID) {
         default: return SHADOW_SOLIDITY_NOT_YET_SET
     }
 }
@@ -329,7 +329,7 @@ const backRightZ  = 7
  * after a rotation equal to the yaw of the current graph node object.
  */
 const rotate_rectangle = (c, newZ, newX, oldZ, oldX) => {
-    let obj = GeoRenderer.gCurGraphNodeObject.wrapperObjectNode.wrapperObject
+    let obj = GeoRenderer.gCurGraphNodeObject.object
     c[newZ] = oldZ * coss(obj.rawData[oFaceAngleYaw]) - oldX * sins(obj.rawData[oFaceAngleYaw]);
     c[newX] = oldZ * sins(obj.rawData[oFaceAngleYaw]) + oldX * coss(obj.rawData[oFaceAngleYaw]);
 }

--- a/src/game/SpawnObject.js
+++ b/src/game/SpawnObject.js
@@ -10,38 +10,29 @@ class SpawnObject {
     }
 
     clear_object_lists() {
+        const gObjectLists = ObjectListProc.gObjectLists
         for (let i = 0; i < ObjectListProc.NUM_OBJ_LISTS; i++) {
-            ObjectListProc.gObjectLists[i].next = ObjectListProc.gObjectLists[i]
-            ObjectListProc.gObjectLists[i].prev = ObjectListProc.gObjectLists[i]
-            // ObjectListProc.gObjectLists[i].gfx.wrapperObjectNode = null
+            gObjectLists[i].next = gObjectLists[i]
+            gObjectLists[i].prev = gObjectLists[i]
         }
     }
 
     try_allocate_object(destList) {
-        const objNode = {
+        const obj = {
             gfx: {},
-            next: null,
-            prev: null
+            next: null, prev: null,
+            activeFlags: 0,
+            rawData: new Array(0x50).fill(0)
         }
-        init_graph_node(objNode.gfx, GRAPH_NODE_TYPE_OBJECT)
+        init_graph_node(obj.gfx, GRAPH_NODE_TYPE_OBJECT)
+        obj.gfx.object = obj
 
-        objNode.gfx.wrapperObjectNode = objNode
-        const obj = { header: objNode, activeFlags: 0, rawData: new Array(0x50).fill(0) }
-        objNode.wrapperObject = obj
+        obj.prev = destList.prev
+        obj.next = destList
+        destList.prev.next = obj
+        destList.prev = obj
 
-        // if (!destList.gfx.wrapperObjectNode) { /// no object has been initialized yet
-        //     Object.assign(destList, objNode)
-        //     destList.prev = destList
-        //     destList.next = destList
-        // }
-
-        objNode.prev = destList.prev
-        objNode.next = destList
-        destList.prev.next = objNode
-        destList.prev = objNode
-
-        // geo_remove_child(objNode.gfx)
-        geo_add_child(gLinker.GeoLayout.gObjParentGraphNode, objNode.gfx)
+        geo_add_child(gLinker.GeoLayout.gObjParentGraphNode, obj.gfx)
         return obj
     }
 
@@ -83,9 +74,9 @@ class SpawnObject {
         obj.rawData[oDistanceToMario] = 19000.0
         obj.rawData[oRoom] = -1
     
-        obj.header.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
-        obj.header.gfx.pos = [ -10000.0, -10000.0, -10000.0 ]
-        obj.header.gfx.throwMatrix = null
+        obj.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
+        obj.gfx.pos = [ -10000.0, -10000.0, -10000.0 ]
+        obj.gfx.throwMatrix = null
 
         return obj
     }
@@ -109,16 +100,15 @@ class SpawnObject {
         obj.activeFlags = ACTIVE_FLAGS_DEACTIVATED
         obj.prevObj = null
 
-        obj.header.gfx.throwMatrix = null
+        obj.gfx.throwMatrix = null
 
         //func_803206F8 TODO
-        geo_remove_child(obj.header.gfx)
-        // geo_add_child(gLinker.GeoLayout.gObjParentGraphNode, obj.header.gfx)
+        geo_remove_child(obj.gfx)
 
-        obj.header.gfx.flags &= ~GRAPH_RENDER_BILLBOARD
-        obj.header.gfx.flags &= ~GRAPH_RENDER_ACTIVE
+        obj.gfx.flags &= ~GRAPH_RENDER_BILLBOARD
+        obj.gfx.flags &= ~GRAPH_RENDER_ACTIVE
 
-        this.deallocate_object(obj.header)
+        this.deallocate_object(obj)
     }
 
 

--- a/src/game/SpawnSound.js
+++ b/src/game/SpawnSound.js
@@ -55,14 +55,14 @@ export const create_sound_spawner = (soundMagic) => {
  * separate left/right leg functions that went unused.
  */
 export const cur_obj_play_sound_1 = (soundMagic) => {
-    if (ObjectListProc.gCurrentObject.header.gfx.flags & GRAPH_RENDER_ACTIVE) {
-        play_sound(soundMagic, ObjectListProc.gCurrentObject.header.gfx.cameraToObject)
+    if (ObjectListProc.gCurrentObject.gfx.flags & GRAPH_RENDER_ACTIVE) {
+        play_sound(soundMagic, ObjectListProc.gCurrentObject.gfx.cameraToObject)
     }
 }
 
 export const cur_obj_play_sound_2 = (soundMagic) => {
-    if (ObjectListProc.gCurrentObject.header.gfx.flags & GRAPH_RENDER_ACTIVE) {
-        play_sound(soundMagic, ObjectListProc.gCurrentObject.header.gfx.cameraToObject)
+    if (ObjectListProc.gCurrentObject.gfx.flags & GRAPH_RENDER_ACTIVE) {
+        play_sound(soundMagic, ObjectListProc.gCurrentObject.gfx.cameraToObject)
     }
 }
 

--- a/src/game/SurfaceLoad.js
+++ b/src/game/SurfaceLoad.js
@@ -329,8 +329,8 @@ class SurfaceLoad {
 
         let numVertices = collisionData.data[collisionData.dataIndex++]
 
-        if (ObjectListProc.gCurrentObject.header.gfx.throwMatrix == null) {
-            ObjectListProc.gCurrentObject.header.gfx.throwMatrix = objectTransform
+        if (ObjectListProc.gCurrentObject.gfx.throwMatrix == null) {
+            ObjectListProc.gCurrentObject.gfx.throwMatrix = objectTransform
             obj_build_transform_from_pos_and_angle(ObjectListProc.gCurrentObject, O_POS_INDEX, O_FACE_ANGLE_INDEX)
         }
 
@@ -418,9 +418,9 @@ class SurfaceLoad {
 
 
         if (marioDist < ObjectListProc.gCurrentObject.rawData[oDrawingDistance]) {
-            ObjectListProc.gCurrentObject.header.gfx.flags |= GRAPH_RENDER_ACTIVE
+            ObjectListProc.gCurrentObject.gfx.flags |= GRAPH_RENDER_ACTIVE
         } else {
-            ObjectListProc.gCurrentObject.header.gfx.flags &= ~GRAPH_RENDER_ACTIVE
+            ObjectListProc.gCurrentObject.gfx.flags &= ~GRAPH_RENDER_ACTIVE
         }
     }
 }

--- a/src/game/behaviors/bhv_castle_flag_init.inc.js
+++ b/src/game/behaviors/bhv_castle_flag_init.inc.js
@@ -3,7 +3,7 @@ import * as _Linker from "../../game/Linker"
 
 export const bhv_castle_flag_init = () => {
     const o = gLinker.ObjectListProcessor.gCurrentObject
-    o.header.gfx.unk38.animFrame = Math.floor(Math.random() * 28.0)
+    o.gfx.unk38.animFrame = Math.floor(Math.random() * 28.0)
 }
 
 

--- a/src/game/behaviors/bobomb.inc.js
+++ b/src/game/behaviors/bobomb.inc.js
@@ -90,7 +90,7 @@ const bobomb_act_chase_mario = () => {
     const o = gLinker.ObjectListProcessor.gCurrentObject
     const gMarioObject = gLinker.ObjectListProcessor.gMarioObject
 
-    const sp1a = ++o.header.gfx.unk38.animFrame
+    const sp1a = ++o.gfx.unk38.animFrame
     o.rawData[oForwardVel] = 20.0
 
     const collisionFlags = object_step()
@@ -146,7 +146,7 @@ const bobomb_check_interactions = () => {
 
     if ((o.rawData[oInteractStatus] & INT_STATUS_INTERACTED) != 0) {
         if ((o.rawData[oInteractStatus] & INT_STATUS_MARIO_UNK1) != 0) {
-            o.rawData[oMoveAngleYaw] = gMarioObject.header.gfx.angle[1]
+            o.rawData[oMoveAngleYaw] = gMarioObject.gfx.angle[1]
             o.rawData[oForwardVel] = 25.0
             o.rawData[oVelY] = 30.0
             o.rawData[oAction] = BOBOMB_ACT_LAUNCHED
@@ -233,7 +233,7 @@ const bobomb_held_loop = () => {
     const o = gLinker.ObjectListProcessor.gCurrentObject
     const gMarioObject = gLinker.ObjectListProcessor.gMarioObject
 
-    o.header.gfx.flags |= GRAPH_RENDER_INVISIBLE
+    o.gfx.flags |= GRAPH_RENDER_INVISIBLE
     cur_obj_init_animation(1)
     cur_obj_set_pos_relative(gMarioObject, 0, 60.0, 100.0)
 
@@ -251,7 +251,7 @@ const bobomb_dropped_loop = () => {
     const o = gLinker.ObjectListProcessor.gCurrentObject
     cur_obj_get_dropped()
 
-    o.header.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
+    o.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
     cur_obj_init_animation(0)
 
     o.rawData[oHeldState] = 0
@@ -262,7 +262,7 @@ const bobomb_thrown_loop = () => {
     const o = gLinker.ObjectListProcessor.gCurrentObject
     cur_obj_enable_rendering()
 
-    o.header.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
+    o.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
     o.rawData[oHeldState] = 0
     o.rawData[oFlags] &= ~0x8; /* bit 3 */
     o.rawData[oForwardVel] = 25.0
@@ -348,7 +348,7 @@ const bhv_bobomb_buddy_init = () => {
 
 const bobomb_buddy_act_idle = () => {
     const o = gLinker.ObjectListProcessor.gCurrentObject
-    let sp1a = o.header.gfx.unk38.animFrame
+    let sp1a = o.gfx.unk38.animFrame
 
     o.rawData[oBobombBuddyPosXCopy] = o.rawData[oPosX]
     o.rawData[oBobombBuddyPosYCopy] = o.rawData[oPosY]
@@ -454,7 +454,7 @@ const bobomb_buddy_act_talk = () => {
 
 const bobomb_buddy_act_turn_to_talk = () => {
     const o = gLinker.ObjectListProcessor.gCurrentObject
-    let /*s16*/ sp1e = o.header.gfx.unk38.animFrame
+    let /*s16*/ sp1e = o.gfx.unk38.animFrame
     if ((sp1e == 5) || (sp1e == 16)) {
         cur_obj_play_sound_2(SOUND_OBJ_BOBOMB_WALK)
     }

--- a/src/game/behaviors/bowling_ball.inc.js
+++ b/src/game/behaviors/bowling_ball.inc.js
@@ -238,7 +238,7 @@ const bhv_generic_bowling_ball_spawner_loop = () => {
         o.rawData[oTimer] = 0
 
     if (is_point_within_radius_of_mario(o.rawData[oPosX], o.rawData[oPosY], o.rawData[oPosZ], 1000)
-        || (o.rawData[oPosY] < gMarioObject.header.gfx.pos[1]))
+        || (o.rawData[oPosY] < gMarioObject.gfx.pos[1]))
         return
 
     if ((o.rawData[oTimer] & o.rawData[oBBallSpawnerPeriodMinus1]) == 0) /* Modulus */
@@ -261,7 +261,7 @@ const bhv_thi_bowling_ball_spawner_loop = () => {
         o.rawData[oTimer] = 0
 
     if (is_point_within_radius_of_mario(o.rawData[oPosX], o.rawData[oPosY], o.rawData[oPosZ], 800)
-        || (o.rawData[oPosY] < gMarioObject.header.gfx.pos[1]))
+        || (o.rawData[oPosY] < gMarioObject.gfx.pos[1]))
         return
 
     if ((o.rawData[oTimer] % 64) == 0) {
@@ -323,7 +323,7 @@ const bhv_free_bowling_ball_roll_loop = () => {
         cur_obj_play_sound_2(SOUND_GENERAL_QUIET_POUND1_LOWPRIO)
 
     if (!is_point_within_radius_of_mario(o.rawData[oPosX], o.rawData[oPosY], o.rawData[oPosZ], 6000)) {
-        o.header.gfx.flags |= GRAPH_RENDER_INVISIBLE
+        o.gfx.flags |= GRAPH_RENDER_INVISIBLE
         cur_obj_become_intangible()
 
         o.rawData[oPosX] = o.rawData[oHomeX]
@@ -342,7 +342,7 @@ const bhv_free_bowling_ball_loop = () => {
         case FREE_BBALL_ACT_IDLE:
             if (is_point_within_radius_of_mario(o.rawData[oPosX], o.rawData[oPosY], o.rawData[oPosZ], 3000)) {
                 o.rawData[oAction] = FREE_BBALL_ACT_ROLL
-                o.header.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
+                o.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
                 cur_obj_become_tangible()
             }
             break

--- a/src/game/behaviors/bowser_key_cutscene.inc.js
+++ b/src/game/behaviors/bowser_key_cutscene.inc.js
@@ -4,15 +4,15 @@ import { oBowserKeyScale } from "../../include/object_constants"
 
 export const geo_scale_bowser_key = (run, node) => {
     if (run == 1) {
-        let sp4 = gLinker.GeoRenderer.gCurGraphNodeObject
-        node.next.scale = sp4.rawData[oBowserKeyScale]
+        let obj = gLinker.GeoRenderer.gCurGraphNodeObject.object
+        node.next.scale = obj.rawData[oBowserKeyScale]
     }
     return 0
 }
 
 // void bhv_bowser_key_unlock_door_loop(void) {
 //     s32 animTimer;
-//     animTimer = o->header.gfx.animInfo.animFrame;
+//     animTimer = o->.gfx.animInfo.animFrame;
 //     cur_obj_init_animation_with_sound(0);
 //     if (animTimer < 38)
 //         o->oBowserKeyScale = 0.0f;
@@ -31,7 +31,7 @@ export const geo_scale_bowser_key = (run, node) => {
 // }
 
 // void bhv_bowser_key_course_exit_loop(void) {
-//     s32 animTimer = o->header.gfx.animInfo.animFrame;
+//     s32 animTimer = o->.gfx.animInfo.animFrame;
 //     cur_obj_init_animation_with_sound(1);
 //     if (animTimer < 38)
 //         o->oBowserKeyScale = 0.2f;

--- a/src/game/behaviors/breakable_box_small.inc.js
+++ b/src/game/behaviors/breakable_box_small.inc.js
@@ -88,10 +88,10 @@ const breakable_box_small_released_loop = () => {
       // Begin flashing
     if (o.rawData[oBreakableBoxSmallFramesSinceReleased] > 810) {
         if (o.rawData[oBreakableBoxSmallFramesSinceReleased] & 1) {
-            o.header.gfx.flags |= GRAPH_RENDER_INVISIBLE
+            o.gfx.flags |= GRAPH_RENDER_INVISIBLE
         }
         else {
-            o.header.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
+            o.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
         }
     }
 
@@ -129,7 +129,7 @@ const breakable_box_small_get_dropped = () => {
     cur_obj_become_tangible()
     cur_obj_enable_rendering()
     cur_obj_get_dropped()
-    o.header.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
+    o.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
     o.rawData[oHeldState] = 0
     o.rawData[oBreakableBoxSmallReleased] = 1
     o.rawData[oBreakableBoxSmallFramesSinceReleased] = 0
@@ -139,7 +139,7 @@ const breakable_box_small_get_thrown = () => {
     const o = gLinker.ObjectListProcessor.gCurrentObject
     cur_obj_become_tangible()
     cur_obj_enable_rendering()
-    o.header.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
+    o.gfx.flags &= ~GRAPH_RENDER_INVISIBLE
     o.rawData[oHeldState] = 0
     o.rawData[oFlags] &= ~0x08
     o.rawData[oForwardVel] = 40.0

--- a/src/game/behaviors/butterfly.inc.js
+++ b/src/game/behaviors/butterfly.inc.js
@@ -21,7 +21,7 @@ const bhv_butterfly_init = () => {
     cur_obj_init_animation(1)
 
     o.oButterflyYPhase = int16(random_float() * 100)
-    o.header.gfx.unk38.animFrame = int16(random_float() * 7)
+    o.gfx.unk38.animFrame = int16(random_float() * 7)
     o.rawData[oHomeX] = o.rawData[oPosX]
     o.rawData[oHomeY] = o.rawData[oPosY]
     o.rawData[oHomeZ] = o.rawData[oPosZ]
@@ -82,7 +82,7 @@ const butterfly_act_rest = () => {
         cur_obj_init_animation(0)
 
         o.rawData[oAction] = BUTTERFLY_ACT_FOLLOW_MARIO
-        o.rawData[oMoveAngleYaw] = gMarioObject.header.gfx.angle[1]
+        o.rawData[oMoveAngleYaw] = gMarioObject.gfx.angle[1]
     }
 }
 

--- a/src/game/behaviors/cannon.inc.js
+++ b/src/game/behaviors/cannon.inc.js
@@ -140,7 +140,7 @@ const bhv_cannon_base_loop = () => {
 const bhv_cannon_barrel_loop = () => {
     const o = gLinker.ObjectListProcessor.gCurrentObject
     const parent = o.parentObj
-    if (parent.header.gfx.flags & GRAPH_RENDER_ACTIVE) {
+    if (parent.gfx.flags & GRAPH_RENDER_ACTIVE) {
         cur_obj_enable_rendering()
         obj_copy_pos(o, o.parentObj)
         o.rawData[oMoveAngleYaw] = o.parentObj.rawData[oMoveAngleYaw]

--- a/src/game/behaviors/cap.inc.js
+++ b/src/game/behaviors/cap.inc.js
@@ -130,7 +130,7 @@ const bhv_wing_cap_init = () => {
 const cap_scale_vertically = () => {
     const o = gLinker.ObjectListProcessor.gCurrentObject
     o.rawData[oCapUnkF8] += 0x2000
-    o.header.gfx.scale[1] = coss(o.rawData[oCapUnkF8]) * 0.3 + 0.7
+    o.gfx.scale[1] = coss(o.rawData[oCapUnkF8]) * 0.3 + 0.7
     if (o.rawData[oCapUnkF8] == 0x10000) {
         o.rawData[oCapUnkF8] = 0
         o.rawData[oCapUnkF4] = 2

--- a/src/game/behaviors/checkerboard_platform.inc.js
+++ b/src/game/behaviors/checkerboard_platform.inc.js
@@ -23,7 +23,7 @@ const bhv_checkerboard_elevator_group_init = () => {
 
 		const sp2C = spawn_object_relative(i, 0, i * sp3C, sp38, o, MODEL_CHECKERBOARD_PLATFORM, bhvCheckerboardPlatformSub)
 		sp2C.rawData[oCheckerBoardPlatformUnk1AC] = checkerPlatformData[sp34].unk2
-		sp2C.header.gfx.scale = [...checkerPlatformData[sp34].unk1]
+		sp2C.gfx.scale = [...checkerPlatformData[sp34].unk1]
 	}
 }
 

--- a/src/game/behaviors/door.inc.js
+++ b/src/game/behaviors/door.inc.js
@@ -181,11 +181,11 @@ export const bhv_star_door_loop_2 = () => {
         sp4 = 1
     }
     if (sp4 == 1) {
-        o.header.gfx.flags |= GRAPH_RENDER_ACTIVE
+        o.gfx.flags |= GRAPH_RENDER_ACTIVE
         // D_8035FEE4++
     }
     if (sp4 == 0) {
-        o.header.gfx.flags &= ~GRAPH_RENDER_ACTIVE
+        o.gfx.flags &= ~GRAPH_RENDER_ACTIVE
     }
     o.rawData[oDoorUnk88] = sp4
 }

--- a/src/game/behaviors/exclamation_box.inc.js
+++ b/src/game/behaviors/exclamation_box.inc.js
@@ -149,9 +149,9 @@ const exclamation_box_act_3 = () => {
     o.rawData[oExclamationBoxUnkF4] = (-sins(o.rawData[oExclamationBoxUnkFC]) + 1.0) * 0.5 + 1.0
     o.rawData[oGraphYOffset] = (-sins(o.rawData[oExclamationBoxUnkFC]) + 1.0) * 26.0
     o.rawData[oExclamationBoxUnkFC] = s16(o.rawData[oExclamationBoxUnkFC] + 0x1000)
-    o.header.gfx.scale[0] = o.rawData[oExclamationBoxUnkF4] * 2.0
-    o.header.gfx.scale[1] = o.rawData[oExclamationBoxUnkF8] * 2.0
-    o.header.gfx.scale[2] = o.rawData[oExclamationBoxUnkF4] * 2.0
+    o.gfx.scale[0] = o.rawData[oExclamationBoxUnkF4] * 2.0
+    o.gfx.scale[1] = o.rawData[oExclamationBoxUnkF8] * 2.0
+    o.gfx.scale[2] = o.rawData[oExclamationBoxUnkF4] * 2.0
     if (o.rawData[oTimer] == 7) {
         o.rawData[oAction] = 4
     }

--- a/src/game/behaviors/fish.inc.js
+++ b/src/game/behaviors/fish.inc.js
@@ -277,7 +277,7 @@ const fish_act_flee = () => {
 const fish_act_init = () => {
     const o = gLinker.ObjectListProcessor.gCurrentObject
     cur_obj_init_animation_with_accel_and_sound(0, 1)
-    o.header.gfx.unk38.animFrame = int16(random_float() * 28)
+    o.gfx.unk38.animFrame = int16(random_float() * 28)
     o.oFishDepthDistance = random_float() * 300
     cur_obj_scale(random_float() * 0.4 + 0.8)
     o.rawData[oAction] = FISH_ACT_ROAM

--- a/src/game/behaviors/mushroom_1up.inc.js
+++ b/src/game/behaviors/mushroom_1up.inc.js
@@ -50,9 +50,9 @@ const bhv_1up_init = () => {
 // }
 
 // void pole_1up_move_towards_mario(void) {
-//     f32 sp34 = gMarioObject->header.gfx.pos[0] - o->oPosX;
-//     f32 sp30 = gMarioObject->header.gfx.pos[1] + 120.0f - o->oPosY;
-//     f32 sp2C = gMarioObject->header.gfx.pos[2] - o->oPosZ;
+//     f32 sp34 = gMarioObject->.gfx.pos[0] - o->oPosX;
+//     f32 sp30 = gMarioObject->.gfx.pos[1] + 120.0f - o->oPosY;
+//     f32 sp2C = gMarioObject->.gfx.pos[2] - o->oPosZ;
 //     s16 sp2A = atan2s(sqrtf(sqr(sp34) + sqr(sp2C)), sp30);
 
 //     obj_turn_toward_object(o, gMarioObject, 16, 0x1000);
@@ -220,11 +220,11 @@ const bhv_1up_hidden_loop = () => {
 //     s16 sp26;
 //     switch (o->oAction) {
 //         case 0:
-//             o->header.gfx.flags |= GRAPH_RENDER_INVISIBLE;
+//             o->.gfx.flags |= GRAPH_RENDER_INVISIBLE;
 //             if (o->o1UpHiddenUnkF4 == o->oBehParams2ndByte) {
 //                 o->oVelY = 40.0f;
 //                 o->oAction = 3;
-//                 o->header.gfx.flags &= ~GRAPH_RENDER_INVISIBLE;
+//                 o->.gfx.flags &= ~GRAPH_RENDER_INVISIBLE;
 //                 play_sound(SOUND_GENERAL2_1UP_APPEAR, gGlobalSoundSource);
 //             }
 //             break;
@@ -272,11 +272,11 @@ const bhv_1up_hidden_in_pole_loop = () => {
 //     UNUSED s16 sp26;
 //     switch (o->oAction) {
 //         case 0:
-//             o->header.gfx.flags |= GRAPH_RENDER_INVISIBLE;
+//             o->.gfx.flags |= GRAPH_RENDER_INVISIBLE;
 //             if (o->o1UpHiddenUnkF4 == o->oBehParams2ndByte) {
 //                 o->oVelY = 40.0f;
 //                 o->oAction = 3;
-//                 o->header.gfx.flags &= ~GRAPH_RENDER_INVISIBLE;
+//                 o->.gfx.flags &= ~GRAPH_RENDER_INVISIBLE;
 //                 play_sound(SOUND_GENERAL2_1UP_APPEAR, gGlobalSoundSource);
 //             }
 //             break;

--- a/src/game/behaviors/sound_spawner.inc.js
+++ b/src/game/behaviors/sound_spawner.inc.js
@@ -6,7 +6,7 @@ import { play_sound } from "../../audio/external"
 
 export const bhv_sound_spawner_init = () => {
     const o = gLinker.ObjectListProcessor.gCurrentObject
-    play_sound(o.rawData[oSoundEffectUnkF4], o.header.gfx.cameraToObject)
+    play_sound(o.rawData[oSoundEffectUnkF4], o.gfx.cameraToObject)
 }
 
 

--- a/src/game/behaviors/water_bomb.inc.js
+++ b/src/game/behaviors/water_bomb.inc.js
@@ -184,13 +184,13 @@ const water_bomb_act_drop = () => {
         o.rawData[oWaterBombOnGround] = 0
     }
 
-    o.header.gfx.scale[1] = o.rawData[oWaterBombVerticalStretch] + 1.0
+    o.gfx.scale[1] = o.rawData[oWaterBombVerticalStretch] + 1.0
 
     stretch = o.rawData[oWaterBombVerticalStretch]
     if (o.rawData[oWaterBombNumBounces] == 3.0) {
         stretch *= 4.0
     }
-    o.header.gfx.scale[0] = o.header.gfx.scale[2] = 1.0 - stretch
+    o.gfx.scale[0] = o.gfx.scale[2] = 1.0 - stretch
 
     cur_obj_move_standard(78)
 }
@@ -238,11 +238,11 @@ const water_bomb_act_shot_from_cannon = () => {
             cur_obj_spawn_particles(sWaterBombCannonParticle)
         }
 
-        if (o.header.gfx.scale[1] > 1.2) {
-            o.header.gfx.scale[1] -= 0.1
+        if (o.gfx.scale[1] > 1.2) {
+            o.gfx.scale[1] -= 0.1
         }
 
-        o.header.gfx.scale[0] = o.header.gfx.scale[2] = 2.0 - o.header.gfx.scale[1]
+        o.gfx.scale[0] = o.gfx.scale[2] = 2.0 - o.gfx.scale[1]
         cur_obj_set_pos_via_transform()
     }
 }
@@ -256,7 +256,7 @@ const bhv_water_bomb_update = () => {
     if (o.rawData[oAction] == WATER_BOMB_ACT_SHOT_FROM_CANNON) {
         water_bomb_act_shot_from_cannon()
     } else {
-        o.rawData[oGraphYOffset] = 40.0 * o.header.gfx.scale[1]
+        o.rawData[oGraphYOffset] = 40.0 * o.gfx.scale[1]
         cur_obj_update_floor_and_walls()
 
         switch (o.rawData[oAction]) {

--- a/src/game/behaviors/water_bomb_cannon.inc.js
+++ b/src/game/behaviors/water_bomb_cannon.inc.js
@@ -47,7 +47,7 @@ const bhv_bubble_cannon_barrel_loop = () => {
                     let val04 = spawn_object(o, MODEL_WATER_BOMB, 'bhvWaterBomb')
                     if (val04 != null) {
                         val04.rawData[oForwardVel] = -100.0
-                        val04.header.gfx.scale[1] = 1.7
+                        val04.gfx.scale[1] = 1.7
                     }
 
                     gLinker.Camera.set_camera_shake_from_point(SHAKE_POS_MEDIUM, o.rawData[oPosX], o.rawData[oPosY], o.rawData[oPosZ])

--- a/src/game/behaviors/water_objs.inc.js
+++ b/src/game/behaviors/water_objs.inc.js
@@ -43,8 +43,8 @@ export const bhv_water_air_bubble_loop = () => {
     const o = ObjectListProc.gCurrentObject
     const gMarioObject = ObjectListProc.gMarioObject
 
-    o.header.gfx.scale[0] = sins(o.rawData[oWaterObjUnkF4]) * 0.5 + 4
-    o.header.gfx.scale[1] = -sins(o.rawData[oWaterObjUnkF4]) * 0.5 + 4
+    o.gfx.scale[0] = sins(o.rawData[oWaterObjUnkF4]) * 0.5 + 4
+    o.gfx.scale[1] = -sins(o.rawData[oWaterObjUnkF4]) * 0.5 + 4
     o.rawData[oWaterObjUnkF4] += 0x400
     if (o.rawData[oTimer] < 30) {
         cur_obj_become_intangible()
@@ -86,9 +86,9 @@ export const bhv_bubble_maybe_loop = () => {
     o.rawData[oPosY] += random_float() * 3 + 6
     o.rawData[oPosX] += random_float() * 10 - 5
     o.rawData[oPosZ] += random_float() * 10 - 5
-    o.header.gfx.scale[0] = sins(o.rawData[oWaterObjUnkF4]) * 0.2 + 1.0
+    o.gfx.scale[0] = sins(o.rawData[oWaterObjUnkF4]) * 0.2 + 1.0
     o.rawData[oWaterObjUnkF4] += o.rawData[oWaterObjUnkFC]
-    o.header.gfx.scale[1] = sins(o.rawData[oWaterObjUnkF8]) * 0.2 + 1.0
+    o.gfx.scale[1] = sins(o.rawData[oWaterObjUnkF8]) * 0.2 + 1.0
     o.rawData[oWaterObjUnkF8] += o.rawData[oWaterObjUnk100]
 }
 
@@ -97,9 +97,9 @@ export const bhv_small_water_wave_loop = () => {
 
     const water_level = SurfaceCollision.find_water_level(o.rawData[oPosX], o.rawData[oPosZ])
 
-    o.header.gfx.scale[0] = sins(o.rawData[oWaterObjUnkF4]) * 0.2 + 1.0
+    o.gfx.scale[0] = sins(o.rawData[oWaterObjUnkF4]) * 0.2 + 1.0
     o.rawData[oWaterObjUnkF4] += o.rawData[oWaterObjUnkFC]
-    o.header.gfx.scale[1] = sins(o.rawData[oWaterObjUnkF8]) * 0.2 + 1.0
+    o.gfx.scale[1] = sins(o.rawData[oWaterObjUnkF8]) * 0.2 + 1.0
     o.rawData[oWaterObjUnkF8] += o.rawData[oWaterObjUnk100]
 
     if (o.rawData[oPosY] > water_level) { // bubble hits water surface
@@ -117,9 +117,9 @@ export const bhv_small_water_wave_loop = () => {
 
 const scale_bubble_sin = () => {
     const o = ObjectListProc.gCurrentObject
-    o.header.gfx.scale[0] = sins(o.rawData[oWaterObjUnkF4]) * 0.5 + 2.0
+    o.gfx.scale[0] = sins(o.rawData[oWaterObjUnkF4]) * 0.5 + 2.0
     o.rawData[oWaterObjUnkF4] += o.rawData[oWaterObjUnkFC]
-    o.header.gfx.scale[1] = sins(o.rawData[oWaterObjUnkF8]) * 0.5 + 2.0
+    o.gfx.scale[1] = sins(o.rawData[oWaterObjUnkF8]) * 0.5 + 2.0
     o.rawData[oWaterObjUnkF8] += o.rawData[oWaterObjUnk100]
 }
 

--- a/src/game/behaviors/water_splashes_and_waves.inc.js
+++ b/src/game/behaviors/water_splashes_and_waves.inc.js
@@ -116,9 +116,9 @@ const bhv_water_droplet_loop = () => {
 
     if (o.rawData[oTimer] == 0) {
         // if (cur_obj_has_model(MODEL_FISH))
-        //     o.header.gfx.flags &= ~GRAPH_RENDER_BILLBOARD;
+        //     o.gfx.flags &= ~GRAPH_RENDER_BILLBOARD;
         // else
-            o.header.gfx.flags |= GRAPH_RENDER_BILLBOARD;
+            o.gfx.flags |= GRAPH_RENDER_BILLBOARD;
         o.rawData[oFaceAngleYaw] = random_int16()
     }
     // Apply gravity
@@ -181,14 +181,14 @@ const bhv_wave_trail_shrink = () => {
     o.rawData[oPosY] = waterLevel + 5
 
     if (o.rawData[oTimer] == 0)
-        o.oWaveTrailSize = o.header.gfx.scale[0]
+        o.oWaveTrailSize = o.gfx.scale[0]
 
     if (o.rawData[oAnimState] > 3) {
         o.oWaveTrailSize = o.oWaveTrailSize - 0.1 // Shrink the wave
         if (o.oWaveTrailSize < 0)
             o.oWaveTrailSize = 0
-        o.header.gfx.scale[0] = o.oWaveTrailSize
-        o.header.gfx.scale[2] = o.oWaveTrailSize
+        o.gfx.scale[0] = o.oWaveTrailSize
+        o.gfx.scale[2] = o.oWaveTrailSize
     }
 }
 

--- a/src/game/behaviors/white_puff_explode.inc.js
+++ b/src/game/behaviors/white_puff_explode.inc.js
@@ -10,7 +10,7 @@ export const bhv_white_puff_exploding_loop = () => {
 
     if (o.rawData[oTimer] == 0) {
         cur_obj_compute_vel_xz()
-        o.rawData[oWhitePuffUnkF4] = o.header.gfx.scale[0]
+        o.rawData[oWhitePuffUnkF4] = o.gfx.scale[0]
         switch (o.rawData[oBehParams2ndByte]) {
             case 2:
                 o.rawData[oOpacity] = 254

--- a/src/game/behaviors/yoshi.inc.js
+++ b/src/game/behaviors/yoshi.inc.js
@@ -49,7 +49,7 @@ const bhv_yoshi_init = () => {
 
 const yoshi_walk_loop = () => {
     const o = gLinker.ObjectListProcessor.gCurrentObject
-   let /*s16*/sp24 = o.header.gfx.unk38.animFrame
+   let /*s16*/sp24 = o.gfx.unk38.animFrame
 
     o.rawData[oForwardVel] = 10.0
     let sp26 = object_step()
@@ -127,7 +127,7 @@ const yoshi_talk_loop = () => {
 }
 
 // void yoshi_walk_and_jump_off_roof_loop(void) {
-//     s16 sp26 = o->header.gfx.unk38.animFrame;
+//     s16 sp26 = o->.gfx.unk38.animFrame;
 
 //     o->oForwardVel = 10.0f;
 //     object_step();


### PR DESCRIPTION
simplify graph node and object models

Clear out last(?) vestiges of C struct “shadowing”.

Objects now simply have a gfx field that’s a graphnode, and graphnodes that are for objects have an object field that points to (is) it.