### PR TITLE
fix water level

### DIFF
--- a/src/engine/SurfaceCollision.js
+++ b/src/engine/SurfaceCollision.js
@@ -1,19 +1,16 @@
-import { LEVEL_BOUNDARY_MAX, CELL_SIZE, SURFACE_FLAG_NO_CAM_COLLISION, SURFACE_CAMERA_BOUNDARY, SURFACE_FLAG_X_PROJECTION } from "../include/surface_terrains"
-import { SurfaceLoadInstance as SurfaceLoad } from "../game/SurfaceLoad"
-import { ObjectListProcessorInstance as ObjectListProcessor } from "../game/ObjectListProcessor"
-// import { SpawnObjectInstance as Spawn } from "../game/SpawnObject"
-
 import * as _Linker from "../game/Linker"
+import * as _SurfaceLoad from "../game/SurfaceLoad"
+
+import {
+    LEVEL_BOUNDARY_MAX, CELL_SIZE, SURFACE_FLAG_NO_CAM_COLLISION, SURFACE_CAMERA_BOUNDARY, SURFACE_FLAG_X_PROJECTION,
+    FLOOR_LOWER_LIMIT
+} from "../include/surface_terrains"
 
 class SurfaceCollision {
-    constructor() {
-        gLinker.SurfaceCollision = this
-    }
-
     find_water_level(x, z) {
-        let waterLevel = -11000.0
+        let waterLevel = FLOOR_LOWER_LIMIT
 
-        const p = ObjectListProcessor.gEnvironmentRegions /// array
+        const p = gLinker.ObjectListProcessor.gEnvironmentRegions /// array
 
         if (p && p[0]) {
             const numRegions = p[0]
@@ -237,7 +234,7 @@ class SurfaceCollision {
 
 
             // Determine if we are checking for the camera or not.
-            if (ObjectListProcessor.gCheckingSurfaceCollisionsForCamera != 0) {
+            if (gLinker.ObjectListProcessor.gCheckingSurfaceCollisionsForCamera != 0) {
                 if (surf.flags & SURFACE_FLAG_NO_CAM_COLLISION) continue 
             }
             // If we are not checking for the camera, ignore camera only floors.
@@ -289,7 +286,7 @@ class SurfaceCollision {
             if ((z3 - z) * (x1 - x3) - (x3 - x) * (z1 - z3) > 0) { continue }
 
             // Determine if we are checking for the camera or not.
-            if (ObjectListProcessor.gCheckingSurfaceCollisionsForCamera != 0) {
+            if (gLinker.ObjectListProcessor.gCheckingSurfaceCollisionsForCamera != 0) {
                 if (surf.flags & SURFACE_FLAG_NO_CAM_COLLISION) { continue }
             }
             // If we are not checking for the camera, ignore camera only floors.
@@ -346,7 +343,7 @@ class SurfaceCollision {
             if ((z3 - z) * (x1 - x3) - (x3 - x) * (z1 - z3) < 0) { continue }
 
             // Determine if we are checking for the camera or not.
-            if (ObjectListProcessor.gCheckingSurfaceCollisionsForCamera != 0) {
+            if (gLinker.ObjectListProcessor.gCheckingSurfaceCollisionsForCamera != 0) {
                 if (surf.flags & SURFACE_FLAG_NO_CAM_COLLISION) { continue }
             }
             // If we are not checking for the camera, ignore camera only floors.
@@ -380,3 +377,4 @@ class SurfaceCollision {
 }
 
 export const SurfaceCollisionInstance = new SurfaceCollision()
+gLinker.SurfaceCollision = SurfaceCollisionInstance

--- a/src/game/Area.js
+++ b/src/game/Area.js
@@ -82,8 +82,23 @@ class Area {
         }
     }
 
+    clear_area_graph_nodes() {
+        if (this.gCurrentArea) {
+            geo_call_global_function_nodes(this.gCurrentArea.geometryLayoutData, GEO_CONTEXT_AREA_UNLOAD)
+            this.gCurrentArea = null
+            this.gWarpTransition.isActive = 0
+        }
+
+        this.gAreas.forEach((areaData) => {
+            if (areaData.geometryLayoutData) {
+                geo_call_global_function_nodes(areaData.geometryLayoutData, GEO_CONTEXT_AREA_INIT)
+                areaData.geometryLayoutData = null
+            }
+        })
+    }
+
     load_area(index) {
-        if (!this.gCurrentArea && this.gAreas[index]) {
+        if (!this.gCurrentArea && this.gAreas[index].geometryLayoutData) {
             this.gCurrentArea = this.gAreas[index]
             this.gCurAreaIndex = this.gCurrentArea.index
 
@@ -236,21 +251,6 @@ class Area {
         })
     }
 
-
-    clear_area_graph_nodes() {
-        if (this.gCurrentArea) {
-            geo_call_global_function_nodes(this.gCurrentArea.geometryLayoutData, GEO_CONTEXT_AREA_UNLOAD)
-            this.gCurrentArea = null
-            this.gWarpTransition.isActive = 0
-        }
-
-        this.gAreas.forEach((areaData, i) => {
-            if (areaData.geometryLayoutData) {
-                geo_call_global_function_nodes(areaData.geometryLayoutData, GEO_CONTEXT_AREA_INIT)
-                areaData.geometryLayoutData = null
-            }
-        })
-    }
 
     render_game() {
         if (this.gCurrentArea && !this.gWarpTransition.pauseRendering) {

--- a/src/game/Mario.js
+++ b/src/game/Mario.js
@@ -1733,7 +1733,6 @@ const mario_update_hitbox_and_cap_model = (m) => {
 }
 
 const update_mario_health = (m) => {
-
     if (m.health >= 0x100) {
 
         // When already healing or hurting Mario, Mario's HP is not changed any more here.
@@ -1794,7 +1793,6 @@ const update_mario_button_inputs = (m, playerInput) => {
 }
 
 const update_mario_joystick_inputs = (m, playerInput) => {
-
     const mag = playerInput.stickMag
 
     m.intendedMag = mag / 2.0
@@ -1813,7 +1811,6 @@ const update_mario_joystick_inputs = (m, playerInput) => {
 }
 
 const update_mario_geometry_inputs = (m) => {
-
     m.floorHeight = SurfaceCollision.find_floor(m.pos[0], m.pos[1], m.pos[2], m)
 
     if (!m.floor) {

--- a/src/game/MarioActionsAirborne.js
+++ b/src/game/MarioActionsAirborne.js
@@ -1,6 +1,5 @@
 import * as _Linker from "./Linker"
 
-import { LevelUpdateInstance as LevelUpdate } from "./LevelUpdate"
 import { CameraInstance as Camera           } from "./Camera"
 import * as CAMERA from "./Camera"
 
@@ -1586,7 +1585,7 @@ export const act_lava_boost = (m) => {
     }
 
     if (m.health < 0x100) {
-        LevelUpdate.level_trigger_warp(m, WARP_OP_DEATH)
+        gLinker.LevelUpdate.level_trigger_warp(m, WARP_OP_DEATH)
     }
 
     m.marioBodyState.eyeState = MARIO_EYES_DEAD

--- a/src/game/MovingTexture.js
+++ b/src/game/MovingTexture.js
@@ -301,12 +301,19 @@ const movtex_gen_quads_id = (id, y, movetexQuadsSegmented) => {
     }
 }
 
+/**
+ * Geo script responsible for drawing quads with a moving texture at the height
+ * of the corresponding water region. The node's parameter determines which quad
+ * collection is drawn, see moving_texture.h.
+ */
 export const geo_movtex_draw_water_regions = (callContext, node) => {
     const gfx = []
 
     if (callContext == GEO_CONTEXT_RENDER) {
         gMovtexVtxColor = MOVTEX_VTX_COLOR_DEFAULT
-        if (ObjectListProc.gEnvironmentRegions == undefined) return gfx
+        if (!ObjectListProc.gEnvironmentRegions) {
+            return gfx
+        }
         const numWaterBoxes = ObjectListProc.gEnvironmentRegions[0]
 
         if (node.parameter == JRB_MOVTEX_INTIAL_MIST) {


### PR DESCRIPTION
Add missing

`gLinker.ObjectListProcessor.gEnvironmentRegions = null`

to `load_area_terrain` so that the water level is reset when entering a new area. Without it, it retains the terrain info from the previous area, evident in the splashes while walking around in the castle basement.