### PR TITLE
Fix color code importing button

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -267,7 +267,7 @@
                     <br>
                     <div style="justify-content:center">
                         <button class="blue-button" style="justify-content:center;"
-                                onclick="window.myMario.skinData = window.parseColorCode($(`#ccPasteArea`).val()); $(`#ccPasteArea`).val('')">
+                                onclick="window.myMario.skinData = window.parseColorCode(document.getElementById('ccPasteArea').value); document.getElementById('ccPasteArea').value = ''">
                             Import Color Code
                         </button>
                     </div>


### PR DESCRIPTION
some jQuery stuff was still linked to it, and since jQuery doesn't exist anymore, that threw an error, fixed it.