### PR TITLE
Fix death barrier crash bug

### DIFF
--- a/src/game/Interaction.js
+++ b/src/game/Interaction.js
@@ -70,7 +70,8 @@ import {
     sBackwardKnockbackActions,
     set_forward_vel,
     set_mario_action,
-    sForwardKnockbackActions               } from "./Mario"
+    sForwardKnockbackActions,
+    respawn_player               } from "./Mario"
 import { GameInstance as Game } from "./Game"
 import { AreaInstance as Area } from "./Area"
 import * as MarioConstants from "../include/mario_constants"
@@ -215,7 +216,7 @@ const check_death_barrier = (m) => {
 
     /// Temp code because death is not implemented
     if (m.pos[1] < m.floorHeight + 2048) {
-		Mario.respawn_player(m)
+		respawn_player(m)
 	}
 
 }

--- a/src/mmo/cosmetics.js
+++ b/src/mmo/cosmetics.js
@@ -434,7 +434,7 @@ export const recvSkinData = (skinMsg) => {
     }
 
     if (socket_id === networkData.mySocketID ||
-        networkData.remotePlayers[socket_id] == null) { console.log(`socket ${socket_id} does not exist, skipping network data loading.`); return }
+        networkData.remotePlayers[socket_id] == null) return
 
     const skinDataMsg = skinMsg.getSkindata()
     const skinData = {


### PR DESCRIPTION
While testing sm64js before deployment to the main site I found a bug where Mario's respawn function isn't imported correctly at the death barrier code, besides that everything else appears to be working correctly.