### PR TITLE
G_IM_FMT_DIRECT & Deadzone fix

### DIFF
--- a/src/game/MarioActionsMoving.js
+++ b/src/game/MarioActionsMoving.js
@@ -123,6 +123,10 @@ const update_walking_speed = (m) => {
 
     targetSpeed = m.intendedMag < maxTargetSpeed ? m.intendedMag : maxTargetSpeed
 
+    // Players with low deadzones/thresholds can start off with a much slower speed ~ watch?v=9DB2zWmJBgU
+    if (m.forwardVel <= 8.0) {
+        m.forwardVel = Math.min(m.intendedMag, 8.0)
+    }
     if (m.forwardVel <= 0.0) {
         m.forwardVel += 1.1
     } else if (m.forwardVel <= targetSpeed) {

--- a/src/graphics/n64GfxProcessor.js
+++ b/src/graphics/n64GfxProcessor.js
@@ -414,13 +414,21 @@ export class n64GfxProcessor {
 
     }
 
+    import_texture_rgbaTrue(tile) {
+
+        WebGL.upload_texture(this.rdp.loaded_texture[tile].textureData.splice(2), this.rdp.loaded_texture[tile].textureData[0]+1, this.rdp.loaded_texture[tile].textureData[1]+1)
+
+    }
+
     import_texture(tile) {
         const fmt = this.rdp.texture_tile.fmt
         const siz = this.rdp.texture_tile.siz
 
         if (this.texture_cache_lookup(tile, this.rdp.loaded_texture[tile].textureData)) return
 
-        if (fmt == Gbi.G_IM_FMT_RGBA) {
+        if (fmt == Gbi.G_IM_FMT_DIRECT) {
+            this.import_texture_rgbaTrue(tile)
+        } else if (fmt == Gbi.G_IM_FMT_RGBA) {
             if (siz == Gbi.G_IM_SIZ_16b) {
                 this.import_texture_rgba16(tile)
             } else {

--- a/src/graphics/n64GfxProcessor.js
+++ b/src/graphics/n64GfxProcessor.js
@@ -416,7 +416,7 @@ export class n64GfxProcessor {
 
     import_texture_rgbaTrue(tile) {
 
-        WebGL.upload_texture(this.rdp.loaded_texture[tile].textureData.splice(2), this.rdp.loaded_texture[tile].textureData[0]+1, this.rdp.loaded_texture[tile].textureData[1]+1)
+        WebGL.upload_texture(this.rdp.loaded_texture[tile].textureData.splice(4), ((this.rdp.loaded_texture[tile].textureData[0]<<8)+this.rdp.loaded_texture[tile].textureData[1])+1, ((this.rdp.loaded_texture[tile].textureData[2]<<8)+this.rdp.loaded_texture[tile].textureData[3])+1)
 
     }
 

--- a/src/include/gbi.js
+++ b/src/include/gbi.js
@@ -254,6 +254,7 @@ export const G_IM_FMT_YUV	=  1
 export const G_IM_FMT_CI	= 2
 export const G_IM_FMT_IA =	3
 export const G_IM_FMT_I	=  4
+export const G_IM_FMT_DIRECT = 16
 
 /*
  * G_SETIMG siz: set image pixel size


### PR DESCRIPTION
Untested custom texture format
Max width/height is 65536, no loss or compression so use rarely if at all
This is just here now incase it ever becomes needed 