### PR TITLE
(REDUNDANT)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,5 @@
 dist
 *lock.json
 node_modules
-testdb.json
 .vs*
 .DS_Store
-extractTools/.assets-local.txt
-extractTools/n64graphics
-extractTools/mio0
-extractTools/skyconv
-extractTools/n64graphics.exe
-extractTools/mio0.exe
-extractTools/skyconv.exe


### PR DESCRIPTION
It no longer needs `testdb.json` cause only classic MMO had `testdb.json`, vanilla never did.
Extracttools was also removed due to it no longer being in the project