### PR TITLE
fix: correct unkown→unknown typo in Mario.js

### DIFF
--- a/src/game/Mario.js
+++ b/src/game/Mario.js
@@ -2175,7 +2175,7 @@ export const execute_mario_action = () => {
                     inLoop = mario_execute_object_action(LevelUpdate.gMarioState)
                     break
 
-                default: throw "unkown action group"
+                default: throw "unknown action group"
             }
         }
 


### PR DESCRIPTION
## Summary
Corrects the typo `unkown` → `unknown` in game error message.

## Changes
- Line 2178: `throw "unkown action group"` → `throw "unknown action group"`

## Testing
- No functional change, typo correction only